### PR TITLE
[RSPEED-240] Fix config and history wrong paths

### DIFF
--- a/command_line_assistant/__main__.py
+++ b/command_line_assistant/__main__.py
@@ -2,8 +2,8 @@ import argparse
 import logging
 import os
 import sys
+from pathlib import Path
 
-from command_line_assistant import utils
 from command_line_assistant.config import (
     CONFIG_DEFAULT_PATH,
     load_config_file,
@@ -62,7 +62,7 @@ def get_args():
 def main():
     parser, args = get_args()
 
-    config_file = utils.expand_user_path(args.config)
+    config_file = Path(args.config).expanduser()
     config = load_config_file(config_file)
 
     enforce_script_session = config.output.enforce_script

--- a/command_line_assistant/config.py
+++ b/command_line_assistant/config.py
@@ -10,9 +10,8 @@ try:
 except ImportError:
     import tomli as tomllib
 
-from command_line_assistant import utils
 
-CONFIG_DEFAULT_PATH: Path = Path("~/.config/shellai/config.toml")
+CONFIG_DEFAULT_PATH: Path = Path("~/.config/command-line-assistant/config.toml")
 
 # tomllib does not support writting files, so we will create our own.
 CONFIG_TEMPLATE = """\
@@ -47,10 +46,10 @@ class OutputSchema(
     def __new__(
         cls,
         enforce_script: bool = False,
-        file: str = "/tmp/shellai_output.txt",
+        file: str = "/tmp/command-line-assistant_output.txt",
         prompt_separator: str = "$",
     ):
-        file = utils.expand_user_path(file)
+        file = Path(file).expanduser()
         return super(OutputSchema, cls).__new__(
             cls, enforce_script, file, prompt_separator
         )
@@ -66,10 +65,10 @@ class HistorySchema(namedtuple("History", ["enabled", "file", "max_size"])):
     def __new__(
         cls,
         enabled: bool = True,
-        file: str = "~/.local/share/shellai/shellai_history.json",
+        file: str = "~/.local/share/command-line-assistant/command-line-assistant_history.json",
         max_size: int = 100,
     ):
-        file = utils.expand_user_path(file)
+        file = Path(file).expanduser()
         return super(HistorySchema, cls).__new__(cls, enabled, file, max_size)
 
 
@@ -146,7 +145,7 @@ def _read_config_file(config_file: Path) -> Config:
 
 
 def load_config_file(config_file: Path) -> Config:
-    """Load configuration file for shellai.
+    """Load configuration file for command-line-assistant.
 
     If the user specifies a path where no config file is located, we will create one with default values.
     """

--- a/command_line_assistant/history.py
+++ b/command_line_assistant/history.py
@@ -38,7 +38,9 @@ def handle_history_write(config: Config, history: list, response: str) -> None:
         return
 
     filepath = config.history.file
-    filepath.makedirs(mode=0o755)
+
+    if not filepath.exists():
+        filepath.parent.mkdir(mode=0o755)
 
     if response:
         history.append({"role": "assistant", "content": response})

--- a/command_line_assistant/utils.py
+++ b/command_line_assistant/utils.py
@@ -2,7 +2,6 @@ import logging
 import os
 import select
 import sys
-from pathlib import Path
 
 import yaml
 
@@ -38,12 +37,3 @@ def get_payload(query: str) -> dict:
     # {"role": "user", "content": "how do I enable selinux?"},
     payload = {"query": query}
     return payload
-
-
-def expand_user_path(file_path: str) -> Path:
-    """Helper method to expand user provided path."""
-    path = Path(file_path)
-    if not path.exists():
-        raise FileNotFoundError(f"Current file does not exist or was not found: {path}")
-
-    return Path(path).expanduser()

--- a/config.toml
+++ b/config.toml
@@ -2,13 +2,13 @@
 # otherwise recording via script session will be enforced
 enforce_script = false
 # file with output(s) of regular commands (e.g. ls, echo, etc.)
-file = "/tmp/shellai_output.txt"
+file = "/tmp/command-line-assistant_output.txt"
 # Keep non-empty if your file contains only output of commands (not prompt itself)
 prompt_separator = "$"
 
 [history]
 enabled = true
-file = "~/.local/share/shellai/shellai_history.json"
+file = "~/.local/share/command-line-assistant/command-line-assistant_history.json"
 # max number of queries in history (including responses)
 max_size = 100
 


### PR DESCRIPTION
There were a couple of leftovers when we renamed the project from shellai to command-line-assistant, and also, we were handling how to create the folders and files in the wrong way.