### PR TITLE
[RSPEED-241] Drop builds for EPEL 8

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,7 +12,6 @@ jobs:
     owner: "@rhel-lightspeed"
     project: command-line-assistant
     targets:
-      - epel-8-x86_64
       - epel-9-x86_64
       - epel-10-x86_64
     actions:
@@ -27,7 +26,6 @@ jobs:
     owner: "@rhel-lightspeed"
     project: command-line-assistant
     targets:
-      - epel-8-x86_64
       - epel-9-x86_64
       - epel-10-x86_64
     actions:


### PR DESCRIPTION
We are not supporting EPEL 8 for this project publication in the meantime. So there is no need to support it for now. Also, it will help us with using newer python versions.