### PR TITLE
Add pyright sanity check

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           pdm install -v
           pdm info
+          echo "$(pdm venv --path in-project)/bin" >> $GITHUB_PATH
 
       - name: Run pyright
         uses: jakebailey/pyright-action@v2

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,8 +1,10 @@
 name: Sanity
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   sanity:
@@ -19,9 +21,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup PDM
+        uses: pdm-project/setup-pdm@v4
+        with:
+          version: 2.20.1
+          python-version: ${{ matrix.python-version }}
+          cache: true
+
+      - name: Install dependencies
+        run: |
+          pdm install -v
+          pdm info
+
       - name: Run pyright
         uses: jakebailey/pyright-action@v2
         with:
           version: 1.1.389
           python-version: ${{ matrix.python-version }}
-

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -39,3 +39,4 @@ jobs:
         with:
           version: 1.1.389
           python-version: ${{ matrix.python-version }}
+          annotate: errors

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,0 +1,27 @@
+name: Sanity
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+    name: Sanity - ${{ matrix.python-version }}
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version:
+          - '3.9'
+          - '3.12'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run pyright
+        uses: jakebailey/pyright-action@v2
+        with:
+          version: 1.1.389
+          python-version: ${{ matrix.python-version }}
+

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,7 @@ name: Unit tests
 
 on:
   push:
-    bracnhes:
+    branches:
       - main
   pull_request:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
 ci:
   autoupdate_schedule: quarterly
+  skip:
+    # https://github.com/pre-commit-ci/issues/issues/55
+    - pyright
 
 minimum_pre_commit_version: "2.9.0"
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
     hooks:
     - id: pyright
       additional_dependencies:
+        - pyright[nodejs]
         - pytest
         - requests
         - tomli; python_version<"3.11"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,15 @@ repos:
           - https://github.com/rhel-lightspeed/command-line-assistant.git
         stages: [manual, pre-push]
 
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.389
+    hooks:
+    - id: pyright
+      additional_dependencies:
+        - pytest
+        - requests
+        - tomli; python_version<"3.11"
+
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.21.2
     hooks:

--- a/command_line_assistant/__main__.py
+++ b/command_line_assistant/__main__.py
@@ -28,8 +28,7 @@ def main():
 
     if enforce_script_session and (not args.record or not os.path.exists(output_file)):
         parser.error(
-            f"Please call `{sys.argv[0]} --record` first to initialize script session or create the output file.",
-            file=sys.stderr,
+            f"Please call `{sys.argv[0]} --record` first to initialize script session or create the output file."
         )
 
     # NOTE: This needs more refinement, script session can't be combined with other arguments

--- a/command_line_assistant/config.py
+++ b/command_line_assistant/config.py
@@ -11,7 +11,7 @@ from typing import ClassVar
 try:
     import tomllib
 except ImportError:
-    import tomli as tomllib
+    import tomli as tomllib  # type: ignore
 
 
 CONFIG_DEFAULT_PATH: Path = Path("~/.config/command-line-assistant/config.toml")

--- a/command_line_assistant/config.py
+++ b/command_line_assistant/config.py
@@ -9,9 +9,9 @@ from typing import ClassVar
 # tomllib is available in the stdlib after Python3.11. Before that, we import
 # from tomli.
 try:
-    import tomllib
+    import tomllib  # pyright: ignore[reportMissingImports]
 except ImportError:
-    import tomli as tomllib  # type: ignore
+    import tomli as tomllib  # pyright: ignore[reportMissingImports]
 
 
 CONFIG_DEFAULT_PATH: Path = Path("~/.config/command-line-assistant/config.toml")

--- a/command_line_assistant/config.py
+++ b/command_line_assistant/config.py
@@ -61,7 +61,7 @@ class LoggingSchema:
             )
 
     def __post_init__(self):
-        self.file = Path(self.file).expanduser()
+        self.file: Path = Path(self.file).expanduser()
 
 
 @dataclasses.dataclass
@@ -73,7 +73,7 @@ class OutputSchema:
     prompt_separator: str = "$"
 
     def __post_init__(self):
-        self.file = Path(self.file).expanduser()
+        self.file: Path = Path(self.file).expanduser()
 
 
 @dataclasses.dataclass
@@ -87,7 +87,7 @@ class HistorySchema:
     max_size: int = 100
 
     def __post_init__(self):
-        self.file = Path(self.file).expanduser()
+        self.file: Path = Path(self.file).expanduser()
 
 
 @dataclasses.dataclass

--- a/command_line_assistant/config.py
+++ b/command_line_assistant/config.py
@@ -50,7 +50,9 @@ class LoggingSchema:
         "minimal",
     )
     type: str = "minimal"
-    file: str | Path = "~/.cache/command-line-assistant/command-line-assistant.log"
+    file: str | Path = Path(  # type: ignore
+        "~/.cache/command-line-assistant/command-line-assistant.log"
+    )
 
     def _validate_logging_type(self, type: str):
         if type not in self._logging_types:
@@ -67,7 +69,7 @@ class OutputSchema:
     """This class represents the [output] section of our config.toml file."""
 
     enforce_script: bool = False
-    file: str | Path = "/tmp/command-line-assistant_output.txt"
+    file: str | Path = Path("/tmp/command-line-assistant_output.txt")  # type: ignore
     prompt_separator: str = "$"
 
     def __post_init__(self):
@@ -79,7 +81,7 @@ class HistorySchema:
     """This class represents the [history] section of our config.toml file."""
 
     enabled: bool = True
-    file: str | Path = (
+    file: str | Path = Path(  # type: ignore
         "~/.local/share/command-line-assistant/command-line-assistant_history.json"
     )
     max_size: int = 100

--- a/command_line_assistant/history.py
+++ b/command_line_assistant/history.py
@@ -4,7 +4,7 @@ import logging
 from command_line_assistant.config import Config
 
 
-def handle_history_read(config: Config) -> dict:
+def handle_history_read(config: Config) -> list:
     """
     Reads the history from a file and returns it as a list of dictionaries.
     """


### PR DESCRIPTION
Fix a few bugs/errors discovered by the type checker.

Add type narrowing hints in the config classes to get accurate attribute checking.

Change default values that can be a `str` or `Path` object to `Path` objects.

Add a pre-commit check for easy local testing but use a GitHub action to run type checking in CI. Pre-commit CI doses not allow network access, which prevents installation of `pyright`.

Depends on #44.