### PR TITLE
Only run tests on pushes to main not all branches

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,10 @@
 name: Unit tests
 
-on: [push, pull_request]
+on:
+  push:
+    bracnhes:
+      - main
+  pull_request:
 
 jobs:
   unit_tests:


### PR DESCRIPTION
This avoids running the same job twice when pushing to PR branches.