### PR TITLE
Remove use of slots in dataclasses

### DIFF
--- a/command_line_assistant/config.py
+++ b/command_line_assistant/config.py
@@ -41,24 +41,7 @@ type = "{logging_type}"
 """
 
 
-def dataclass(cls, slots=True):
-    """Custom dataclass decorator to mimic the behavior of dataclass for Python 3.9"""
-    try:
-        return dataclasses.dataclass(cls, slots=slots)
-    except TypeError:
-
-        def wrap(cls):
-            # Create a new dict for our new class.
-            cls_dict = dict(cls.__dict__)
-            field_names = tuple(name for name in cls_dict.keys())
-            # The slots for our class
-            cls_dict["__slots__"] = field_names
-            return dataclasses.dataclass(cls)
-
-        return wrap(cls)
-
-
-@dataclass
+@dataclasses.dataclass
 class LoggingSchema:
     """This class represents the [logging] section of our config.toml file."""
 
@@ -79,7 +62,7 @@ class LoggingSchema:
         self.file = Path(self.file).expanduser()
 
 
-@dataclass
+@dataclasses.dataclass
 class OutputSchema:
     """This class represents the [output] section of our config.toml file."""
 
@@ -91,7 +74,7 @@ class OutputSchema:
         self.file = Path(self.file).expanduser()
 
 
-@dataclass
+@dataclasses.dataclass
 class HistorySchema:
     """This class represents the [history] section of our config.toml file."""
 
@@ -105,7 +88,7 @@ class HistorySchema:
         self.file = Path(self.file).expanduser()
 
 
-@dataclass
+@dataclasses.dataclass
 class BackendSchema:
     """This class represents the [backend] section of our config.toml file."""
 
@@ -113,7 +96,7 @@ class BackendSchema:
     verify_ssl: bool = True
 
 
-@dataclass
+@dataclasses.dataclass
 class Config:
     """Class that holds our configuration file representation.
 


### PR DESCRIPTION
Support for slots in dataclasses was added in 3.10. The workaround we had was confusing the type checker (it's probably the type checker being dumb, but we can get by without using slots to simply things).