### PR TITLE
The connect_signals was triggered the API request twice

### DIFF
--- a/command_line_assistant/dbus/interfaces.py
+++ b/command_line_assistant/dbus/interfaces.py
@@ -16,21 +16,15 @@ from command_line_assistant.history import handle_history_read, handle_history_w
 class QueryInterface(InterfaceTemplate):
     """The DBus interface of a query."""
 
-    def connect_signals(self) -> None:
-        """Connect the signals."""
-        # Watch for property changes based on the query_changed method.
-        self.watch_property("RetrieveAnswer", self.implementation.query_changed)
-
     @property
     def RetrieveAnswer(self) -> Structure:
         """This method is mainly called by the client to retrieve it's answer."""
-        output = Message()
         llm_response = submit(
             self.implementation.query.message, self.implementation.config
         )
-        print("llm_response", llm_response)
-        output.message = llm_response
-        return Message.to_structure(output)
+        message = Message()
+        message.message = llm_response
+        return Message.to_structure(message)
 
     @emits_properties_changed
     def ProcessQuery(self, query: Structure) -> None:

--- a/tests/dbus/test_interfaces.py
+++ b/tests/dbus/test_interfaces.py
@@ -28,12 +28,6 @@ def query_interface(mock_implementation):
 
 
 class TestQueryInterface:
-    def test_connect_signals(self, query_interface, mock_implementation):
-        query_interface.connect_signals()
-        query_interface.watch_property.assert_called_once_with(
-            "RetrieveAnswer", mock_implementation.query_changed
-        )
-
     @patch("command_line_assistant.dbus.interfaces.submit")
     def test_retrieve_answer_success(
         self, mock_submit, query_interface, mock_implementation


### PR DESCRIPTION
The connect_signals method in our QueryContext was triggering the API requests twice (as expected), but this is not the behavior we want. This patch removes this functionality.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
