### PR TITLE
[RSPEED-388] Add exception handling for SSL certificates

### DIFF
--- a/command_line_assistant/daemon/http/session.py
+++ b/command_line_assistant/daemon/http/session.py
@@ -1,6 +1,7 @@
 """Handle the http sessions that the daemon issues to the backend."""
 
 import logging
+from ssl import SSLError
 
 import urllib3
 from requests.sessions import Session
@@ -8,6 +9,7 @@ from requests.sessions import Session
 from command_line_assistant.config import Config
 from command_line_assistant.constants import VERSION
 from command_line_assistant.daemon.http.adapters import RetryAdapter, SSLAdapter
+from command_line_assistant.dbus.exceptions import RequestFailedError
 
 USER_AGENT = f"clad/{VERSION}"
 #: Define the custom user agent for clad
@@ -46,10 +48,20 @@ def get_session(config: Config) -> Session:
         session.verify = False
         return session
 
-    ssl_adapter = SSLAdapter(
-        cert_file=config.backend.auth.cert_file,  # type: ignore
-        key_file=config.backend.auth.key_file,  # type: ignore
-    )
+    try:
+        ssl_adapter = SSLAdapter(
+            cert_file=config.backend.auth.cert_file,  # type: ignore
+            key_file=config.backend.auth.key_file,  # type: ignore
+        )
+    except SSLError as e:
+        raise RequestFailedError(
+            "Failed to load certificate in cert chain. If needed, regenerate the certificate with subscription-manager and try again."
+        ) from e
+    except FileNotFoundError as e:
+        raise RequestFailedError(
+            f"Couldn't find certificate files at '{config.backend.auth.cert_file.parent}' folder."  # pyright: ignore[reportAttributeAccessIssue]
+        ) from e
+
     # Mount the adapter for the given endpoint.
     session.mount(config.backend.endpoint, ssl_adapter)
 


### PR DESCRIPTION
Adding two exception handling for the SSLAdapter class. One for the certificate not being valid, and the second one for the certificate missing on the system.

Without that, the user would receive a nasty error in the client and a not that helpful error in the journald logs.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-388](https://issues.redhat.com/browse/RSPEED-388)

Checklist

- [ ] Jira issue has been made public if possible
- [x] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
