### PR TITLE
Apply NO_COLOR to colored output

### DIFF
--- a/command_line_assistant/rendering/decorators/colors.py
+++ b/command_line_assistant/rendering/decorators/colors.py
@@ -134,8 +134,10 @@ class ColorDecorator(BaseDecorator):
         Returns:
             str: The text itself colored with the requested foreground and (optionally) background color.
         """
-        formatted_text = f"{self.background}{self.foreground}{text}{RESET_ALL}"
-        return formatted_text
+        if not should_disable_color_output():
+            formatted_text = f"{self.background}{self.foreground}{text}{RESET_ALL}"
+            return formatted_text
+        return text
 
 
 def should_disable_color_output() -> bool:


### PR DESCRIPTION
This patch updates the ColorDecorator to not add coloring output if NO_COLOR environment is set.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
