### PR TITLE
[RSPEED-129] Add audit logging capability to CLAD

### DIFF
--- a/command_line_assistant/commands/query.py
+++ b/command_line_assistant/commands/query.py
@@ -1,5 +1,6 @@
 """Module to handle the query command."""
 
+import getpass
 from argparse import Namespace
 from typing import Optional
 
@@ -119,6 +120,8 @@ class QueryCommand(BaseCLICommand):
 
         input_query = Message()
         input_query.message = query
+        # Get the current user
+        input_query.user = getpass.getuser()
         output = "Nothing to see here..."
 
         try:

--- a/command_line_assistant/config/schemas.py
+++ b/command_line_assistant/config/schemas.py
@@ -11,9 +11,15 @@ class LoggingSchema:
 
     Attributes:
         level (str): The level to log. Defaults to "INFO".
+        responses (bool): If the responses should be logged. Defaults to True.
+        question (bool): If the questions should be logged. Defaults to True.
+        users (dict[str, dict[str, bool]]): A dictionary of users and their logging preferences.
     """
 
     level: str = "INFO"
+    responses: bool = True
+    question: bool = True
+    users: dict[str, dict[str, bool]] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Post initialization method to normalize values
@@ -29,6 +35,23 @@ class LoggingSchema:
             )
 
         self.level = self.level.upper()
+
+    def should_log_for_user(self, username: str, log_type: str) -> bool:
+        """Check if logging should be enabled for a specific user and log type.
+
+        Args:
+            username (str): The username to check
+            log_type (str): The type of log ('responses' or 'question')
+
+        Returns:
+            bool: Whether logging should be enabled for this user and log type
+        """
+        # If user has specific settings, use those
+        if username in self.users:
+            return self.users[username].get(log_type, False)
+
+        # Otherwise fall back to global settings
+        return getattr(self, log_type, False)
 
 
 @dataclasses.dataclass

--- a/command_line_assistant/dbus/structures.py
+++ b/command_line_assistant/dbus/structures.py
@@ -10,6 +10,7 @@ class Message(DBusData):
     def __init__(self) -> None:
         """Constructor of class."""
         self._message: Str = ""
+        self._user: Str = ""
         super().__init__()
 
     @property
@@ -29,6 +30,24 @@ class Message(DBusData):
             value (Str): Message to be set to the internal property
         """
         self._message = value
+
+    @property
+    def user(self) -> Str:
+        """Property for internal user attribute.
+
+        Returns:
+            Str: Value of user
+        """
+        return self._user
+
+    @user.setter
+    def user(self, value: Str) -> None:
+        """Set a new user
+
+        Args:
+            value (Str): User to be set to the internal property
+        """
+        self._user = value
 
 
 class HistoryItem(DBusData):

--- a/command_line_assistant/logger.py
+++ b/command_line_assistant/logger.py
@@ -1,7 +1,9 @@
 """Module for logging configuration."""
 
 import copy
+import json
 import logging.config
+from typing import Optional
 
 from command_line_assistant.config import Config
 
@@ -13,7 +15,11 @@ LOGGING_CONFIG_DICTIONARY = {
         "default": {
             "format": "[%(asctime)s] [%(filename)s:%(lineno)d] %(levelname)s: %(message)s",
             "datefmt": "%m/%d/%Y %I:%M:%S %p",
-        }
+        },
+        "audit": {
+            "()": "command_line_assistant.logger._create_audit_formatter",
+            "config": None,  # Will be set in setup_logging
+        },
     },
     "handlers": {
         "console": {
@@ -21,10 +27,99 @@ LOGGING_CONFIG_DICTIONARY = {
             "formatter": "default",
             "stream": "ext://sys.stdout",
         },
+        "audit_file": {
+            "class": "logging.FileHandler",
+            "filename": "/var/log/audit/command-line-assistant.log",
+            "formatter": "audit",
+            "mode": "a",
+        },
     },
-    "loggers": {"root": {"handlers": ["console"], "level": "DEBUG"}},
+    "loggers": {
+        "root": {"handlers": ["console"], "level": "DEBUG"},
+        "audit": {
+            "handlers": ["audit_file", "console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+    },
 }
 #: Define the dictionary configuration for the logger instance
+
+
+class AuditFormatter(logging.Formatter):
+    """Custom formatter that handles user-specific logging configuration."""
+
+    def __init__(
+        self, config: Config, fmt: Optional[str] = None, datefmt: Optional[str] = None
+    ):
+        """Initialize the formatter with config.
+
+        Args:
+            config (Config): The application configuration
+            fmt (Optional[str], optional): Format string. Defaults to None.
+            datefmt (Optional[str], optional): Date format string. Defaults to None.
+        """
+        super().__init__(fmt, datefmt)
+        self._config = config
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format the record based on user-specific settings.
+
+        Args:
+            record (logging.LogRecord): The log record to format
+
+        Note:
+            This method is called by the logging framework to format the log message.
+
+        Example:
+            This is how it will look like in the audit.log file::
+
+            >>> # In case the query and response are disabled for the current user.
+            >>> {"timestamp":"2025-01-03T11:26:37.%fZ","user":"my-user","message":"Query executed successfully.","query":null,"response":null}
+
+            >>> # In case the query and response are enabled for the current user.
+            >>> {"timestamp":"2025-01-03T11:26:37.%fZ","user":"my-user","message":"Query executed successfully.","query":"My query!","response":"My super response"}
+
+        Returns:
+            str: The formatted log message
+        """
+        # Basic structure that will always be included
+        data = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "user": getattr(record, "user", "unknown"),
+            "message": record.getMessage(),
+        }
+
+        is_query_enabled = hasattr(
+            record, "query"
+        ) and self._config.logging.should_log_for_user(data["user"], "question")
+        # Add query if enabled for user
+        data["query"] = record.query if is_query_enabled else None  # type: ignore
+
+        is_response_enabled = hasattr(
+            record, "response"
+        ) and self._config.logging.should_log_for_user(data["user"], "responses")
+        # Add response if enabled for user
+        data["response"] = record.response if is_response_enabled else None  # type: ignore
+
+        # separators will remove whitespace between items
+        # ensure_ascii will properly handle unicode characters.
+        return json.dumps(data, separators=(",", ":"), ensure_ascii=False)
+
+
+def _create_audit_formatter(config: Config) -> AuditFormatter:
+    """Internal method to create a new audit formatter instance.
+
+    Args:
+        config (Config): The application configuration
+
+    Returns:
+        AuditFormatter: The new audit formatter instance.
+    """
+
+    fmt = '{"timestamp": "%(asctime)s", "user": "%(user)s", "message": "%(message)s"%(query)s%(response)s}'
+    datefmt = "%Y-%m-%dT%H:%M:%S.%fZ"
+    return AuditFormatter(config=config, fmt=fmt, datefmt=datefmt)
 
 
 def setup_logging(config: Config):
@@ -36,5 +131,7 @@ def setup_logging(config: Config):
 
     logging_configuration = copy.deepcopy(LOGGING_CONFIG_DICTIONARY)
     logging_configuration["loggers"]["root"]["level"] = config.logging.level
+    # Set the config in the formatter
+    logging_configuration["formatters"]["audit"]["config"] = config
 
     logging.config.dictConfig(logging_configuration)

--- a/data/development/config/command_line_assistant/config.toml
+++ b/data/development/config/command_line_assistant/config.toml
@@ -20,3 +20,8 @@ verify_ssl = false
 
 [logging]
 level = "DEBUG"
+responses = false # Global setting - don't log responses by default
+question = false  # Global setting - don't log questions by default
+
+# User-specific settings
+# users.admin = { responses = true, question = true }

--- a/tests/commands/test_query.py
+++ b/tests/commands/test_query.py
@@ -25,6 +25,7 @@ def mock_dbus_service(mock_proxy):
         # Setup default mock response
         mock_output = Message()
         mock_output.message = "default mock response"
+        mock_output.user = "mock"
         mock_proxy.RetrieveAnswer = lambda: Message.to_structure(mock_output)
 
         yield mock_proxy
@@ -53,15 +54,19 @@ def test_query_command_run(mock_dbus_service, test_input, expected_output, capsy
     # Setup mock response for this specific test
     mock_output = Message()
     mock_output.message = expected_output
+    mock_output.user = "mock"
     mock_dbus_service.RetrieveAnswer = lambda: Message.to_structure(mock_output)
 
-    # Create and run command
-    command = QueryCommand(test_input, None)
-    command.run()
+    with patch("command_line_assistant.commands.query.getpass.getuser") as mock_getuser:
+        mock_getuser.return_value = "mock"
+        # Create and run command
+        command = QueryCommand(test_input, None)
+        command.run()
 
     # Verify ProcessQuery was called with correct input
     expected_input = Message()
     expected_input.message = test_input
+    expected_input.user = "mock"
     mock_dbus_service.ProcessQuery.assert_called_once_with(
         Message.to_structure(expected_input)
     )
@@ -76,6 +81,7 @@ def test_query_command_empty_response(mock_dbus_service, capsys):
     # Setup empty response
     mock_output = Message()
     mock_output.message = ""
+    mock_output.user = "mock"
     mock_dbus_service.RetrieveAnswer = lambda: Message.to_structure(mock_output)
 
     command = QueryCommand("test query", None)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,9 +1,110 @@
+import json
 import logging
+from unittest.mock import patch
+
+import pytest
+
+from command_line_assistant.logger import (
+    AuditFormatter,
+    _create_audit_formatter,
+    setup_logging,
+)
 
 
-def test_verbose_logging(caplog):
-    log = logging.getLogger()
+@pytest.fixture
+def audit_formatter(mock_config):
+    """Create an AuditFormatter instance."""
+    return AuditFormatter(config=mock_config)
 
-    log.info("test")
 
-    assert "test" in caplog.records[-1].message
+def test_audit_formatter_format(audit_formatter):
+    """Test basic formatting of log records."""
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="Test message",
+        args=(),
+        exc_info=None,
+    )
+    record.user = "testuser"
+
+    formatted = audit_formatter.format(record)
+    data = json.loads(formatted)
+
+    assert "timestamp" in data
+    assert data["user"] == "testuser"
+    assert data["message"] == "Test message"
+    assert data["query"] is None
+    assert data["response"] is None
+
+
+def test_audit_formatter_with_query_and_response(audit_formatter):
+    """Test formatting with query and response fields."""
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="Test message",
+        args=(),
+        exc_info=None,
+    )
+    record.user = "testuser"
+    record.query = "test query"
+    record.response = "test response"
+
+    formatted = audit_formatter.format(record)
+    data = json.loads(formatted)
+
+    assert data["query"] == "test query"
+    assert data["response"] == "test response"
+
+
+def test_create_audit_formatter(mock_config):
+    """Test creation of audit formatter."""
+    formatter = _create_audit_formatter(mock_config)
+    assert isinstance(formatter, AuditFormatter)
+
+
+@patch("logging.config.dictConfig")
+def test_setup_logging(mock_dict_config, mock_config):
+    """Test setup of logging configuration."""
+    mock_config.logging.level = "INFO"
+    setup_logging(mock_config)
+    mock_dict_config.assert_called_once()
+
+
+def test_audit_formatter_user_specific_logging(mock_config):
+    """Test user-specific logging configuration."""
+    # Configure mock for user-specific settings
+    mock_config.logging.users = {"testuser": {"question": True, "responses": False}}
+    formatter = AuditFormatter(config=mock_config)
+
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="Test message",
+        args=(),
+        exc_info=None,
+    )
+    record.user = "testuser"
+    record.query = "test query"
+    record.response = "test response"
+
+    formatted = formatter.format(record)
+    data = json.loads(formatted)
+
+    # Query should be included but response should not for this user
+    assert data["query"] == "test query"
+    assert data["response"] is None
+
+
+def test_setup_logging_invalid_level(mock_config):
+    """Test setup_logging with invalid log level."""
+    mock_config.logging.level = "INVALID_LEVEL"
+    with pytest.raises(ValueError):
+        setup_logging(mock_config)


### PR DESCRIPTION
Now sysadmins can configure the audit logging capabilities for CLAD. The configuration is all set and configurable via the config.toml settings.

By default, all query and responses will be logged to the audit file.

The new settings for the logging configuration contains the following:

- Enable/disable query audit logging
- Enable/disable response audit logging
- The user who made the request
- A timestamp indicating when the request happened
- Ability for the sysadmin to enable/disable query/response for a certian user

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-129](https://issues.redhat.com/browse/RSPEED-129)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
