### PR TITLE
Normalize the folder name to command-line-assistant

### DIFF
--- a/command_line_assistant/config/__init__.py
+++ b/command_line_assistant/config/__init__.py
@@ -23,7 +23,7 @@ except ImportError:
 
 
 CONFIG_FILE_DEFINITION: tuple[str, str] = (
-    "command_line_assistant",
+    "command-line-assistant",
     "config.toml",
 )
 #: Define the config file path.

--- a/packaging/command-line-assistant.spec
+++ b/packaging/command-line-assistant.spec
@@ -43,7 +43,7 @@ A simple wrapper to interact with RAG
 
 # Create needed directories in buildroot
 %{__install} -d %{buildroot}/%{_sbindir}
-%{__install} -d %{buildroot}/%{_sysconfdir}/xdg/%{python_package_src}
+%{__install} -d %{buildroot}/%{_sysconfdir}/xdg/%{name}
 %{__install} -d %{buildroot}/%{_sharedstatedir}/%{name}
 %{__install} -d %{buildroot}/%{_mandir}/man1
 %{__install} -d %{buildroot}/%{_mandir}/man8
@@ -61,7 +61,7 @@ A simple wrapper to interact with RAG
 %{__install} -D -m 0644 data/release/dbus/com.redhat.lightspeed.history.service %{buildroot}/%{_datadir}/dbus-1/system-services/com.redhat.lightspeed.history.service
 
 # Config file
-%{__install} -D -m 0644 data/release/xdg/config.toml %{buildroot}/%{_sysconfdir}/xdg/%{python_package_src}/config.toml
+%{__install} -D -m 0644 data/release/xdg/config.toml %{buildroot}/%{_sysconfdir}/xdg/%{name}/config.toml
 
 # History file
 %{__install} -D -m 0644 data/release/xdg/history.json %{buildroot}/%{_sharedstatedir}/%{name}/history.json
@@ -102,7 +102,7 @@ LICENSE
 %{_datadir}/dbus-1/system-services/com.redhat.lightspeed.history.service
 
 # Config file
-%config %{_sysconfdir}/xdg/%{python_package_src}/config.toml
+%config %{_sysconfdir}/xdg/%{name}/config.toml
 
 # History file
 %{_sharedstatedir}/%{name}/history.json

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -42,7 +42,7 @@ level = "INFO"
 
 def test_load_config_file(tmp_path, monkeypatch, get_config_template):
     config_file_path = tmp_path
-    config_file = config_file_path / "command_line_assistant" / "config.toml"
+    config_file = config_file_path / "command-line-assistant" / "config.toml"
     config_file.parent.mkdir()
     config_file.write_text(get_config_template)
 
@@ -65,7 +65,7 @@ def test_load_config_file_not_found(tmp_path, monkeypatch):
 
 def test_load_config_file_decoded_error(tmp_path, monkeypatch):
     config_file_path = tmp_path
-    config_file = config_file_path / "command_line_assistant" / "config.toml"
+    config_file = config_file_path / "command-line-assistant" / "config.toml"
     config_file.parent.mkdir()
     config_file.write_text("""
 [output]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def mock_config(tmp_path):
     """Fixture to create a mock configuration"""
     cert_file = tmp_path / "cert.pem"
     key_file = tmp_path / "key.pem"
-    history_file = tmp_path / "command_line_assistant" / "history.json"
+    history_file = tmp_path / "command-line-assistant" / "history.json"
 
     cert_file.write_text("cert")
     key_file.write_text("key")


### PR DESCRIPTION
There were a couple of instances where we used the name command_line_assistant instead of command-line-assistant

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
