### PR TITLE
[RSPEED-446] Fix ordering from history results

### DIFF
--- a/command_line_assistant/history/plugins/local.py
+++ b/command_line_assistant/history/plugins/local.py
@@ -5,7 +5,7 @@ import platform
 import uuid
 from datetime import datetime
 
-from sqlalchemy import desc
+from sqlalchemy import asc
 
 from command_line_assistant.config import Config
 from command_line_assistant.daemon.database.manager import DatabaseManager
@@ -71,7 +71,7 @@ class LocalHistory(BaseHistoryPlugin):
                     session.query(HistoryModel)
                     .join(InteractionModel)
                     .filter(HistoryModel.deleted_at.is_(None))
-                    .order_by(desc(HistoryModel.timestamp))
+                    .order_by(asc(HistoryModel.timestamp))
                     .all()
                 )
 

--- a/tests/dbus/test_interfaces.py
+++ b/tests/dbus/test_interfaces.py
@@ -97,6 +97,8 @@ def test_history_interface_get_first_conversation(
         "command_line_assistant.history.manager.HistoryManager", mock_history_entry
     ) as manager:
         manager.write("test query", "test response")
+        manager.write("test query2", "test response2")
+        manager.write("test query3", "test response3")
         response = history_interface.GetFirstConversation()
 
         reconstructed = HistoryEntry.from_structure(response)
@@ -111,12 +113,14 @@ def test_history_interface_get_last_conversation(history_interface, mock_history
         "command_line_assistant.history.manager.HistoryManager", mock_history_entry
     ) as manager:
         manager.write("test query", "test response")
+        manager.write("test query2", "test response2")
+        manager.write("test query3", "test response3")
         response = history_interface.GetLastConversation()
 
         reconstructed = HistoryEntry.from_structure(response)
         assert len(reconstructed.entries) == 1
-        assert reconstructed.entries[0].query == "test query"
-        assert reconstructed.entries[0].response == "test response"
+        assert reconstructed.entries[0].query == "test query3"
+        assert reconstructed.entries[0].response == "test response3"
 
 
 def test_history_interface_get_filtered_conversation(
@@ -127,6 +131,7 @@ def test_history_interface_get_filtered_conversation(
         "command_line_assistant.history.manager.HistoryManager", mock_history_entry
     ) as manager:
         manager.write("test query", "test response")
+        manager.write("not a query", "not a response")
         response = history_interface.GetFilteredConversation(filter="test")
 
         reconstructed = HistoryEntry.from_structure(response)


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-446](https://issues.redhat.com/browse/RSPEED-446)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
