### PR TITLE
Remove json history from rpm spec

### DIFF
--- a/packaging/command-line-assistant.spec
+++ b/packaging/command-line-assistant.spec
@@ -67,9 +67,6 @@ A simple wrapper to interact with RAG
 # Config file
 %{__install} -D -m 0644 data/release/xdg/config.toml %{buildroot}/%{_sysconfdir}/xdg/%{name}/config.toml
 
-# History file
-%{__install} -D -m 0644 data/release/xdg/history.json %{buildroot}/%{_sharedstatedir}/%{name}/history.json
-
 # Manpages
 %{__install} -D -m 0644 data/release/man/%{binary_name}.1 %{buildroot}/%{_mandir}/man1/%{binary_name}.1
 %{__install} -D -m 0644 data/release/man/%{daemon_binary_name}.8 %{buildroot}/%{_mandir}/man8/%{daemon_binary_name}.8
@@ -107,9 +104,6 @@ LICENSE
 
 # Config file
 %config %{_sysconfdir}/xdg/%{name}/config.toml
-
-# History file
-%{_sharedstatedir}/%{name}/history.json
 
 # Manpages
 %{_mandir}/man1/%{binary_name}.1.gz


### PR DESCRIPTION
We don't have the json history anymore, so we can drop it from the rpm spec

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
