### PR TITLE
[RSPEED-465] Redirect to stderr instead of stdout for error msgs

### DIFF
--- a/command_line_assistant/utils/renderers.py
+++ b/command_line_assistant/utils/renderers.py
@@ -20,13 +20,12 @@ def create_error_renderer() -> TextRenderer:
         TextRenderer: Instance of a TextRenderer with correct decorators for
         error output.
     """
-    renderer = TextRenderer()
-    renderer.update(
+    renderer = create_text_renderer(
         [
             EmojiDecorator(emoji="U+1F641"),
             ColorDecorator(foreground="red"),
-            TextWrapDecorator(),
-        ]
+        ],
+        StderrStream(),
     )
 
     return renderer
@@ -39,13 +38,12 @@ def create_warning_renderer() -> TextRenderer:
         TextRenderer: Instance of a TextRenderer with correct decorators for
         error output.
     """
-    renderer = TextRenderer(StderrStream())
-    renderer.update(
+    renderer = create_text_renderer(
         [
             EmojiDecorator(emoji="0x1f914"),
             ColorDecorator(foreground="yellow"),
-            TextWrapDecorator(),
-        ]
+        ],
+        StderrStream(),
     )
 
     return renderer

--- a/tests/commands/test_query.py
+++ b/tests/commands/test_query.py
@@ -105,7 +105,7 @@ def test_query_command_invalid_inputs(mock_dbus_service, test_args, capsys):
     captured = capsys.readouterr()
     assert (
         "\x1b[31m🙁 No input provided. Please provide input via file, stdin, or direct\nquery.\x1b[0m"
-        in captured.out
+        in captured.err
     )
 
 
@@ -245,4 +245,4 @@ def test_dbus_error_handling(exception, expected, mock_dbus_service, capsys):
 
     # Verify error message in stdout
     captured = capsys.readouterr()
-    assert expected in captured.out.strip()
+    assert expected in captured.err.strip()

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -105,7 +105,7 @@ def test_initialize_bad_stdin(capsys):
     captured = capsys.readouterr()
     assert (
         "The stdin provided could not be decoded. Please, make sure it is in\ntextual format."
-        in captured.out
+        in captured.err
     )
 
 

--- a/tests/utils/test_renderers.py
+++ b/tests/utils/test_renderers.py
@@ -11,8 +11,7 @@ def test_create_error_renderer(capsys: pytest.CaptureFixture[str]):
     renderer.render("errored out")
 
     captured = capsys.readouterr()
-    print(captured)
-    assert "\x1b[31m🙁 errored out\x1b[0m\n" in captured.out
+    assert "\x1b[31m🙁 errored out\x1b[0m\n" in captured.err
 
 
 def test_create_spinner_renderer(capsys, mock_stream):


### PR DESCRIPTION
Error messages were going to stdout instead of stderr. This patch fixes this and redirect them to the correct stream.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-465](https://issues.redhat.com/browse/RSPEED-465)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
