### PR TITLE
[RSPEED-23] Add proxy setting for config.toml

### DIFF
--- a/command_line_assistant/config/schemas/backend.py
+++ b/command_line_assistant/config/schemas/backend.py
@@ -30,11 +30,14 @@ class BackendSchema:
 
     Attributes:
         endpoint (str): The endpoint to communicate with.
+        proxies (dict[str, str]): Dictionary of proxies to route the request
         auth (Union[dict, AuthSchema]): The authentication information
     """
 
     endpoint: str = "http://0.0.0.0:8080"
     auth: AuthSchema = dataclasses.field(default_factory=AuthSchema)
+
+    proxies: dict[str, str] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self):
         """Post initialization method to normalize values"""

--- a/command_line_assistant/daemon/http/session.py
+++ b/command_line_assistant/daemon/http/session.py
@@ -34,6 +34,9 @@ def get_session(config: Config) -> Session:
     """
     session = Session()
 
+    # Include the proxies defined by the user. By default, nothing is loaded.
+    session.proxies.update(config.backend.proxies)
+
     # Set up the necessary headers for every session.
     session.headers["User-Agent"] = USER_AGENT
     session.headers["Content-Type"] = "application/json"

--- a/data/development/config/command-line-assistant/config.toml
+++ b/data/development/config/command-line-assistant/config.toml
@@ -15,6 +15,7 @@ connection_string = "~/.local/share/command-line-assistant/history.db"
 
 [backend]
 endpoint = "http://localhost:8000"
+# proxies = { http = "http://localhost:8002", https = "https://localhost:8002" }
 
 [backend.auth]
 cert_file = "data/development/certificate/fake-certificate.pem"

--- a/data/release/xdg/config.toml
+++ b/data/release/xdg/config.toml
@@ -46,7 +46,10 @@ connection_string = "/var/lib/command-line-assistant/history.db"
 # Backend settings for communicating with the external API.
 [backend]
 # The endpoint points to an API server.
-endpoint = "http://localhost:8080"
+endpoint = "https://localhost:8080"
+# Define https proxy to route the request through it.
+# It accepts `username:password@localhost:8002`, for example.
+# proxies = { https = "https://localhost:8002" }
 
 # Configure authentication settings for backend
 [backend.auth]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def mock_config(tmp_path):
                 prompt_separator="$",
             ),
             backend=BackendSchema(
-                endpoint="http://test.endpoint/v1/query",
+                endpoint="http://localhost",
                 auth=AuthSchema(
                     cert_file=cert_file, key_file=key_file, verify_ssl=False
                 ),

--- a/tests/daemon/http/test_query.py
+++ b/tests/daemon/http/test_query.py
@@ -1,8 +1,6 @@
 import pytest
 import responses
 
-from command_line_assistant.config import Config
-from command_line_assistant.config.schemas.backend import AuthSchema, BackendSchema
 from command_line_assistant.daemon.http import query
 from command_line_assistant.dbus.exceptions import RequestFailedError
 
@@ -19,7 +17,7 @@ def default_payload():
 
 
 @responses.activate
-def test_handle_query(default_payload):
+def test_handle_query(default_payload, mock_config):
     responses.post(
         url="http://localhost/infer",
         json={
@@ -27,48 +25,29 @@ def test_handle_query(default_payload):
         },
     )
 
-    config = Config(
-        backend=BackendSchema(
-            endpoint="http://localhost", auth=AuthSchema(verify_ssl=False)
-        )
-    )
-
-    result = query.submit(default_payload, config=config)
-
+    result = query.submit(default_payload, config=mock_config)
     assert result == "test"
 
 
 @responses.activate
-def test_handle_query_raising_status(default_payload):
+def test_handle_query_raising_status(mock_config, default_payload):
     responses.post(
         url="http://localhost/infer",
         status=404,
-    )
-    config = Config(
-        backend=BackendSchema(
-            endpoint="http://localhost/infer", auth=AuthSchema(verify_ssl=False)
-        )
     )
     with pytest.raises(
         RequestFailedError,
         match="There was a problem communicating with the server. Please, try again in a few minutes.",
     ):
-        query.submit(default_payload, config=config)
+        query.submit(default_payload, config=mock_config)
 
 
 @responses.activate
-def test_disable_ssl_verification(caplog, default_payload):
-    responses.post(
-        url="https://localhost/infer", json={"data": {"text": "yeah, test!"}}
-    )
+def test_disable_ssl_verification(caplog, default_payload, mock_config):
+    mock_config.backend.auth.verify_ssl = False
+    responses.post(url="http://localhost/infer", json={"data": {"text": "yeah, test!"}})
 
-    config = Config(
-        backend=BackendSchema(
-            endpoint="https://localhost", auth=AuthSchema(verify_ssl=False)
-        )
-    )
-
-    result = query.submit(default_payload, config=config)
+    result = query.submit(default_payload, config=mock_config)
 
     assert result == "yeah, test!"
     assert (

--- a/tests/daemon/http/test_session.py
+++ b/tests/daemon/http/test_session.py
@@ -97,3 +97,25 @@ def test_session_with_missing_ssl_certificate(tmp_path, mock_config):
 
     with pytest.raises(RequestFailedError, match="Couldn't find certificate files at"):
         get_session(mock_config)
+
+
+@pytest.mark.parametrize(
+    ("proxies",),
+    (
+        ({"http": "http://may-the-force-be-with-you"},),
+        ({},),
+        ({"https": "https://may-the-force-be-with-you"},),
+        (
+            {
+                "http": "http://may-the-force-be-with-you",
+                "https": "https://double-proxy!",
+            },
+        ),
+    ),
+)
+def test_session_with_proxies(proxies, mock_config):
+    mock_config.backend.proxies = proxies
+
+    session = get_session(mock_config)
+
+    assert session.proxies == proxies


### PR DESCRIPTION
Now we can specify a proxy to route the request.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-23](https://issues.redhat.com/browse/RSPEED-23)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
