### PR TITLE
[RSPEED-585] Add simple and interactive chat session

### DIFF
--- a/command_line_assistant/daemon/database/models/chat.py
+++ b/command_line_assistant/daemon/database/models/chat.py
@@ -13,3 +13,4 @@ class ChatModel(BaseModel):
     user_id = Column(GUID(), nullable=False)
     name = Column(String(25), nullable=False)
     description = Column(Text, nullable=True)
+    # mode = Column(String(15), nullable=False)

--- a/command_line_assistant/exceptions.py
+++ b/command_line_assistant/exceptions.py
@@ -1,0 +1,5 @@
+"""Module that holds the exceptions for the client part of the codebase."""
+
+
+class StopInteractiveMode(Exception):
+    """Control the interactive mode execution"""

--- a/command_line_assistant/rendering/renders/interactive.py
+++ b/command_line_assistant/rendering/renders/interactive.py
@@ -1,0 +1,78 @@
+"""Interactive renderer module to handle chat interactive session."""
+
+from typing import Optional
+
+from command_line_assistant.exceptions import StopInteractiveMode
+from command_line_assistant.rendering.base import BaseRenderer, BaseStream
+from command_line_assistant.rendering.stream import StdoutStream
+
+
+class InteractiveRenderer(BaseRenderer):
+    """This is a specialized class to render output based on the `stream` parameter to the terminal.
+
+    Example:
+        This class can be used as this:
+            >>> interactive_renderer = InteractiveRenderer()
+            >>> interactive_renderer.render(">>> ")
+            >>> # Will open an interactive loop waiting for user input
+    """
+
+    def __init__(self, banner: str, stream: Optional[BaseStream] = None) -> None:
+        """Constructor for the class
+
+        Arguments:
+            banner (str): The banner that will greet the user when the interactive mode starts.
+            stream (Optional[OutputStreamWritter], optional): The stream to where the output will be. Can be either `py:StdoutStream` or `py:StderrStream`. Defaults to StdoutStream().
+        """
+        self._banner = banner
+        self._output: str = ""
+        self._first_message = False
+        super().__init__(stream or StdoutStream())
+
+    def render(self, text: str) -> None:
+        """The main function to render thext.
+
+        Note:
+            The text argument here will be used as a prompt.
+
+        Arguments:
+            text (str): The textual value that will be represented in the terminal.
+
+        Raises:
+            StopInteractiveMode: In case the interactive mode should be stopped, we will raise this.
+        """
+        if not self._first_message:
+            self._stream.write(self._banner)
+            self._stream.write("The current seesion does not include running context.")
+            self._first_message = True
+
+        try:
+            user_input = input(text).strip()
+
+            # More commands can be added in the future, but for now, we only have .exit
+            if user_input == ".exit":
+                raise StopInteractiveMode("Stopping interactive mode.")
+
+            self.output = user_input
+        except (KeyboardInterrupt, EOFError) as e:
+            raise StopInteractiveMode(
+                "Detected keyboard interrupt. Stopping interactive mode."
+            ) from e
+
+    @property
+    def output(self) -> str:
+        """Property to get the value of the internal output
+
+        Returns:
+            str: The value of the output stored
+        """
+        return self._output
+
+    @output.setter
+    def output(self, value: str) -> None:
+        """Set the value to the output internal property
+
+        Arguments:
+            value (str): The value to be set
+        """
+        self._output = value

--- a/command_line_assistant/utils/renderers.py
+++ b/command_line_assistant/utils/renderers.py
@@ -8,6 +8,7 @@ from command_line_assistant.rendering.decorators.text import (
     EmojiDecorator,
     TextWrapDecorator,
 )
+from command_line_assistant.rendering.renders.interactive import InteractiveRenderer
 from command_line_assistant.rendering.renders.spinner import SpinnerRenderer
 from command_line_assistant.rendering.renders.text import TextRenderer
 from command_line_assistant.rendering.stream import StderrStream, StdoutStream
@@ -69,6 +70,18 @@ def create_spinner_renderer(
     decorators.append(TextWrapDecorator())
     spinner.update(decorators)
     return spinner
+
+
+def create_interactive_renderer() -> InteractiveRenderer:
+    """Create a new instance of the interactive rendering.
+
+    Returns:
+        InteractiveRenderer: A new instance of the interactive renderer.
+    """
+    interactive = InteractiveRenderer(
+        banner="Welcome to the interactive mode for command line assistant! To exit, press Ctrl + C or type '.exit'."
+    )
+    return interactive
 
 
 def create_text_renderer(

--- a/data/development/config/command-line-assistant/config.toml
+++ b/data/development/config/command-line-assistant/config.toml
@@ -14,7 +14,7 @@ connection_string = "~/.local/share/command-line-assistant/history.db"
 enabled = true
 
 [backend]
-endpoint = "https://rlsapi-rhel-lightspeed--runtime-int.apps.int.spoke.preprod.us-east-1.aws.paas.redhat.com"
+endpoint = "http://localhost:8000"
 # proxies = { http = "http://localhost:8002", https = "https://localhost:8002" }
 
 [backend.auth]

--- a/docs/source/exceptions.rst
+++ b/docs/source/exceptions.rst
@@ -1,0 +1,8 @@
+Exceptions
+==========
+
+.. automodule:: command_line_assistant.exceptions
+   :members:
+   :undoc-members:
+   :private-members:
+   :no-index:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,7 @@ Welcome to Command Line Assistant documentation
    initialize
    logger
    meta
+   exceptions
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/rendering/renders/interactive.rst
+++ b/docs/source/rendering/renders/interactive.rst
@@ -1,0 +1,8 @@
+Interactive
+===========
+
+.. automodule:: command_line_assistant.rendering.renders.interactive
+   :members:
+   :undoc-members:
+   :private-members:
+   :no-index:

--- a/tests/commands/test_chat.py
+++ b/tests/commands/test_chat.py
@@ -25,6 +25,7 @@ def default_namespace():
         query_string=None,
         stdin=None,
         attachment=None,
+        interactive=None,
         list=None,
         delete=None,
         delete_all=None,

--- a/tests/rendering/renders/test_interactive.py
+++ b/tests/rendering/renders/test_interactive.py
@@ -1,0 +1,57 @@
+from unittest.mock import patch
+
+import pytest
+
+from command_line_assistant.exceptions import StopInteractiveMode
+from command_line_assistant.rendering.renders.interactive import InteractiveRenderer
+from command_line_assistant.rendering.stream import StdoutStream
+
+
+@pytest.fixture
+def interactive_renderer():
+    """Fixture to create an InteractiveRenderer instance"""
+    banner = "Welcome to test interactive mode!"
+    return InteractiveRenderer(banner=banner)
+
+
+def test_interactive_renderer_init(interactive_renderer):
+    """Test the initialization of InteractiveRenderer"""
+    assert isinstance(interactive_renderer._stream, StdoutStream)
+    assert interactive_renderer._banner == "Welcome to test interactive mode!"
+    assert interactive_renderer._output == ""
+    assert interactive_renderer._first_message is False
+
+
+@patch("builtins.input", return_value="test input")
+def test_interactive_renderer_input(mock_input, interactive_renderer):
+    """Test that user input is captured correctly"""
+    interactive_renderer.render(">>> ")
+    assert interactive_renderer.output == "test input"
+    mock_input.assert_called_once_with(">>> ")
+
+
+@patch("builtins.input", return_value=".exit")
+def test_interactive_renderer_exit_command(mock_input, interactive_renderer):
+    """Test that .exit command raises StopInteractiveMode"""
+    with pytest.raises(StopInteractiveMode, match="Stopping interactive mode."):
+        interactive_renderer.render(">>> ")
+
+
+@patch("builtins.input", side_effect=KeyboardInterrupt)
+def test_interactive_renderer_keyboard_interrupt(mock_input, interactive_renderer):
+    """Test that KeyboardInterrupt raises StopInteractiveMode"""
+    with pytest.raises(
+        StopInteractiveMode,
+        match="Detected keyboard interrupt. Stopping interactive mode.",
+    ):
+        interactive_renderer.render(">>> ")
+
+
+@patch("builtins.input", side_effect=EOFError)
+def test_interactive_renderer_eof_error(mock_input, interactive_renderer):
+    """Test that EOFError raises StopInteractiveMode"""
+    with pytest.raises(
+        StopInteractiveMode,
+        match="Detected keyboard interrupt. Stopping interactive mode.",
+    ):
+        interactive_renderer.render(">>> ")


### PR DESCRIPTION
Now users can keep chatting in the same REPL sending and receiving messages.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-585](https://issues.redhat.com/browse/RSPEED-585)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
