### PR TITLE
[RSPEED-573, RSPEED-577] Rework audit logging system

### DIFF
--- a/command_line_assistant/config/schemas/logging.py
+++ b/command_line_assistant/config/schemas/logging.py
@@ -1,8 +1,17 @@
 """Schemas for the logging config."""
 
-import copy
 import dataclasses
-import pwd
+
+
+@dataclasses.dataclass
+class AuditSchema:
+    """This class represents the [logging.audit] section of our config.toml file.
+
+    Attributes:
+        enabled (bool): Flag to control if the logging should be enabled or not.
+    """
+
+    enabled: bool = True
 
 
 @dataclasses.dataclass
@@ -17,9 +26,7 @@ class LoggingSchema:
     """
 
     level: str = "INFO"
-    responses: bool = True
-    question: bool = True
-    users: dict[str, dict[str, bool]] = dataclasses.field(default_factory=dict)
+    audit: AuditSchema = dataclasses.field(default_factory=AuditSchema)
 
     def __post_init__(self) -> None:
         """Post initialization method to normalize values
@@ -34,16 +41,4 @@ class LoggingSchema:
                 f"The requested level '{level}' is not allowed. Choose from: {', '.join(allowed_levels)}"
             )
 
-        self.level = self.level.upper()
-
-        if self.users:
-            # Turn any username to their effective_user_id
-            defined_users = copy.deepcopy(self.users)
-            for user in defined_users.keys():
-                try:
-                    effective_user_id = str(pwd.getpwnam(user).pw_uid)
-                    self.users[effective_user_id] = self.users.pop(user)
-                except KeyError as e:
-                    raise ValueError(
-                        f"{user} is not present on the system. Remove it from the configuration."
-                    ) from e
+        self.level = level

--- a/command_line_assistant/daemon/http/query.py
+++ b/command_line_assistant/daemon/http/query.py
@@ -28,12 +28,11 @@ def submit(payload: dict, config: Config) -> str:
     query_endpoint = f"{config.backend.endpoint}/infer"
 
     try:
-        logger.info("Waiting for response from AI...")
         with get_session(config) as session:
             response = session.post(
                 query_endpoint, data=json.dumps(payload), timeout=30
             )
-
+        logger.info("Got response from LLM backend")
         response.raise_for_status()
         data = response.json()
         data = data.get("data", {})

--- a/command_line_assistant/dbus/interfaces/history.py
+++ b/command_line_assistant/dbus/interfaces/history.py
@@ -20,7 +20,6 @@ from command_line_assistant.dbus.structures.history import (
 from command_line_assistant.history.manager import HistoryManager
 from command_line_assistant.history.plugins.local import LocalHistory
 
-audit_logger = logging.getLogger("audit")
 logger = logging.getLogger(__name__)
 
 
@@ -123,7 +122,10 @@ class HistoryInterface(InterfaceTemplate):
         Arguments:
             user_id (Str): The identifier of the user.
         """
-        logger.info("Clearing history entries for user '%s'.", user_id)
+        logger.info(
+            "Clearing history entries for user.",
+            extra={"audit": True, "user_id": user_id},
+        )
         self._history_manager.clear(user_id)
 
     def WriteHistory(
@@ -139,9 +141,8 @@ class HistoryInterface(InterfaceTemplate):
         """
         self._history_manager.write(chat_id, user_id, question, response)
         logger.info(
-            "Wrote a new entry to the user history for user '%s' in chat '%s'.",
-            user_id,
-            chat_id,
+            "Wrote a new entry to the user history for user.",
+            extra={"audit": True, "user_id": user_id, "chat_id": str(chat_id)},
         )
 
 

--- a/command_line_assistant/dbus/server.py
+++ b/command_line_assistant/dbus/server.py
@@ -32,13 +32,15 @@ def _dbus_setup(objects: list[tuple]) -> None:
         SYSTEM_BUS.register_service(obj.service_name)
 
 
+logger = logging.getLogger(__name__)
+
+
 def serve(config: Config):
     """Main function to serve and start the daemon server.
 
     Args:
         config (Config): An instance of the configuration class.
     """
-    logger.info("Starting clad!")
     try:
         _dbus_setup(
             [
@@ -48,6 +50,7 @@ def serve(config: Config):
             ]
         )
 
+        logger.info("Starting clad!")
         loop = EventLoop()
         loop.run()
     finally:

--- a/command_line_assistant/initialize.py
+++ b/command_line_assistant/initialize.py
@@ -1,9 +1,11 @@
 """Main module for the cli."""
 
+import logging
 import sys
 from argparse import ArgumentParser, Namespace
 
 from command_line_assistant.commands import chat, history
+from command_line_assistant.logger import setup_logging
 from command_line_assistant.utils.cli import (
     add_default_command,
     create_argument_parser,
@@ -29,6 +31,9 @@ def register_subcommands() -> ArgumentParser:
     return parser
 
 
+logger = logging.getLogger(__name__)
+
+
 def initialize() -> int:
     """Main function for the cli entrypoint
 
@@ -40,9 +45,7 @@ def initialize() -> int:
 
     try:
         stdin = read_stdin()
-
         args = add_default_command(stdin, sys.argv)
-
         # Small workaround to include the stdin in the namespace object. If it
         # exists, it will have the value of the stdin redirection, otherwise,
         # it will be None.
@@ -53,6 +56,9 @@ def initialize() -> int:
             parser.print_help()
             return 1
 
+        # In case the uder specify the --debug, we will enable the logging here.
+        if args.debug:
+            setup_logging()
         service = args.func(args)
         return service.run()
     except ValueError as e:

--- a/command_line_assistant/logger.py
+++ b/command_line_assistant/logger.py
@@ -3,24 +3,33 @@
 import copy
 import json
 import logging.config
-from typing import Optional
+from logging import LogRecord
+from typing import Any, Optional
 
 from command_line_assistant.config import Config
-from command_line_assistant.daemon.session import UserSessionManager
 
 #: Define the dictionary configuration for the logger instance
 LOGGING_CONFIG_DICTIONARY = {
     "version": 1,
     "disable_existing_loggers": False,
-    "level": "DEBUG",
+    "level": "INFO",
     "formatters": {
         "default": {
             "format": "[%(asctime)s] [%(filename)s:%(lineno)d] %(levelname)s: %(message)s",
             "datefmt": "%m/%d/%Y %I:%M:%S %p",
         },
         "audit": {
-            "()": "command_line_assistant.logger._create_audit_formatter",
-            "config": None,  # Will be set in setup_logging
+            "()": "command_line_assistant.logger.AuditFormatter",
+            "datefmt": "%Y-%m-%dT%H:%M:%S",
+            "format": "[%(asctime)s] [%(filename)s:%(lineno)d] %(levelname)s: %(message)s",
+        },
+    },
+    "filters": {
+        "audit_only": {
+            "()": "command_line_assistant.logger.AuditFilter",
+        },
+        "non_audit_only": {
+            "()": "command_line_assistant.logger.NonAuditFilter",
         },
     },
     "handlers": {
@@ -28,60 +37,86 @@ LOGGING_CONFIG_DICTIONARY = {
             "class": "logging.StreamHandler",
             "formatter": "default",
             "stream": "ext://sys.stdout",
+            "filters": ["non_audit_only"],
         },
-        "audit_file": {
-            "class": "logging.FileHandler",
-            "filename": "/var/log/command-line-assistant/audit.log",
-            "formatter": "audit",
-            "mode": "a",
-        },
-        "audit_journald": {
+        "audit": {
             "class": "logging.StreamHandler",
             "formatter": "audit",
             "stream": "ext://sys.stdout",
+            "filters": ["audit_only"],
         },
     },
     "loggers": {
-        "root": {"handlers": ["console"], "level": "DEBUG"},
-        "audit": {
-            "handlers": ["audit_file", "audit_journald"],
-            "level": "INFO",
-            "propagate": False,
-        },
+        # Root logger
+        "root": {"handlers": ["audit", "console"], "level": "INFO"},
     },
 }
 
+#: Set of keys to skip during auditting. If any of those needs to be in the
+#: audit log, simply remove them from this list.
+EXTRAS_TO_SKIP = (
+    "args",
+    "asctime",
+    "created",
+    "exc_info",
+    "exc_text",
+    "filename",
+    "funcName",
+    "levelname",
+    "levelno",
+    "lineno",
+    "taskName",
+    "module",
+    "server",
+    "thread",
+    "process",
+    "processName",
+    "msecs",
+    "msg",
+    "name",
+    "pathname",
+    "relativeCreated",
+    "stack_info",
+    "threadName",
+    "audit",
+    "user_id",
+)
 
-def _should_log_for_user(effective_user_id: int, config: Config, log_type: str) -> bool:
-    """Check if logging should be enabled for a specific user and log type.
 
-    Args:
-        effective_user_id (int): The effective user id to check if logging is enabled.
-        log_type (str): The type of log ('responses' or 'question')
+class AuditFilter(logging.Filter):
+    """Filter to separate audit logs from regular logs."""
 
-    Returns:
-        bool: Whether logging should be enabled for this user and log type
-    """
-    logging_users = copy.deepcopy(config.logging.users)
-    for user in config.logging.users.keys():
-        user_id = UserSessionManager().get_user_id(int(user))
-        logging_users[user_id] = logging_users.pop(user)
+    def filter(self, record: LogRecord) -> bool:
+        """Filter records based on the presence of audit attribute.
 
-    user_id = UserSessionManager().get_user_id(effective_user_id)
-    # If user has specific settings, use those
-    if user_id in logging_users:
-        return logging_users[user_id].get(log_type, False)
+        Args:
+            record (LogRecord): The log record to check
 
-    # Otherwise fall back to global settings
-    return getattr(config.logging, log_type, False)
+        Returns:
+            bool: True if the record should be processed, False otherwise
+        """
+        return bool(getattr(record, "audit", False))
+
+
+class NonAuditFilter(logging.Filter):
+    """Filter to separate regular logs from audit logs."""
+
+    def filter(self, record: LogRecord) -> bool:
+        """Filter records based on the absence of audit attribute.
+
+        Args:
+            record (LogRecord): The log record to check
+
+        Returns:
+            bool: True if the record should be processed, False otherwise
+        """
+        return not bool(getattr(record, "audit", False))
 
 
 class AuditFormatter(logging.Formatter):
     """Custom formatter that handles user-specific logging configuration."""
 
-    def __init__(
-        self, config: Config, fmt: Optional[str] = None, datefmt: Optional[str] = None
-    ):
+    def __init__(self, fmt: Optional[str] = None, datefmt: Optional[str] = None):
         """Initialize the formatter with config.
 
         Args:
@@ -90,85 +125,85 @@ class AuditFormatter(logging.Formatter):
             datefmt (Optional[str], optional): Date format string. Defaults to None.
         """
         super().__init__(fmt, datefmt)
-        self._config = config
 
-    def format(self, record: logging.LogRecord) -> str:
-        """Format the record based on user-specific settings.
+    def format(self, record: LogRecord) -> str:
+        """Format the record as JSON for journald consumption.
 
         Args:
             record (logging.LogRecord): The log record to format
 
-        Note:
-            This method is called by the logging framework to format the log message.
+        Returns:
+            str: JSON formatted log message
+        """
+        user_id = getattr(record, "user_id", None)
 
-        Example:
-            This is how it will look like in the audit.log file::
+        # Build base structured data
+        structured_data = {
+            "priority": self._get_syslog_priority(record.levelno),
+            "message": record.getMessage(),
+            "timestamp": self.formatTime(record, self.datefmt),
+            "syslog_identifier": "command-line-assistant",
+            "code": {
+                "file": record.filename,
+                "line": record.lineno,
+                "function": record.funcName,
+            },
+            "user_id": user_id,
+            "audit_type": "command-line-assistant-audit",
+            "level": record.levelname,
+        }
 
-            >>> # In case the query and response are disabled for the current user.
-            >>> {"timestamp":"2025-01-03T11:26:37.%fZ","user":"my-user","message":"Query executed successfully.","query":null,"response":null}
+        # Add any additional fields from record
+        extras = self._get_extra_fields(record)
+        if extras:
+            structured_data["audit_data"] = extras
 
-            >>> # In case the query and response are enabled for the current user.
-            >>> {"timestamp":"2025-01-03T11:26:37.%fZ","user":"my-user","message":"Query executed successfully.","query":"My query!","response":"My super response"}
+        return json.dumps(structured_data, default=str)
+
+    def _get_syslog_priority(self, levelno: int) -> int:
+        """Convert Python logging levels to syslog priorities.
+
+        Args:
+            levelno (int): Python logging level number
 
         Returns:
-            str: The formatted log message
+            int: Corresponding syslog priority
         """
-        # Basic structure that will always be included
-        data = {
-            "timestamp": self.formatTime(record, self.datefmt),
-            "user": getattr(record, "user", "unknown"),
-            "message": record.getMessage(),
+        priorities = {
+            logging.CRITICAL: 2,  # LOG_CRIT
+            logging.ERROR: 3,  # LOG_ERR
+            logging.WARNING: 4,  # LOG_WARNING
+            logging.INFO: 6,  # LOG_INFO
+            logging.DEBUG: 7,  # LOG_DEBUG
         }
-        effective_user_id = data["user"]
-        is_query_enabled = hasattr(record, "query") and _should_log_for_user(
-            effective_user_id, self._config, "question"
-        )
-        # Add query if enabled for user
-        data["query"] = record.query if is_query_enabled else None  # type: ignore
+        return priorities.get(levelno, 6)  # Default to INFO
 
-        is_response_enabled = hasattr(record, "response") and _should_log_for_user(
-            effective_user_id, self._config, "responses"
-        )
-        # Add response if enabled for user
-        data["response"] = record.response if is_response_enabled else None  # type: ignore
+    def _get_extra_fields(self, record: LogRecord) -> dict[str, Any]:
+        """Extract additional fields from the record.
 
-        # separators will remove whitespace between items
-        # ensure_ascii will properly handle unicode characters.
-        return json.dumps(data, separators=(",", ":"), ensure_ascii=False)
+        Args:
+            record (LogRecord): The log record
+
+        Returns:
+            dict[str, Any]: Dictionary of extra fields
+        """
+        extras = {}
+        for key, value in record.__dict__.items():
+            if key not in EXTRAS_TO_SKIP:
+                extras[key] = value
+        return extras
 
 
-def _create_audit_formatter(config: Config) -> AuditFormatter:
-    """Internal method to create a new audit formatter instance.
+def setup_logging(config: Optional[Config] = None) -> None:
+    """Setup basic logging functionality.
 
     Note:
-        This appears to be not used, but the logging class will call this
-        function to initialize the formatter options for audit logger.
+        This is intended to be called by the daemon to initialize their logging routine.
 
-        Do not remove this function, only if there is a better idea on how to
-        do it.
-
-    Args:
-        config (Config): The application configuration
-
-    Returns:
-        AuditFormatter: The new audit formatter instance.
-    """
-
-    fmt = '{"timestamp": "%(asctime)s", "user": "%(user)s", "message": "%(message)s"%(query)s%(response)s}'
-    datefmt = "%Y-%m-%dT%H:%M:%S"
-    return AuditFormatter(config=config, fmt=fmt, datefmt=datefmt)
-
-
-def setup_logging(config: Config):
-    """Setup basic logging functionality"
-
-    Args:
+    Arguments:
         config (Config): Instance of a config class.
     """
-
     logging_configuration = copy.deepcopy(LOGGING_CONFIG_DICTIONARY)
-    logging_configuration["loggers"]["root"]["level"] = config.logging.level
-    # Set the config in the formatter
-    logging_configuration["formatters"]["audit"]["config"] = config
-
+    loggin_level = "DEBUG" if not config else config.logging.level
+    logging_configuration["loggers"]["root"]["level"] = loggin_level
     logging.config.dictConfig(logging_configuration)

--- a/data/development/config/command-line-assistant/config.toml
+++ b/data/development/config/command-line-assistant/config.toml
@@ -24,8 +24,6 @@ verify_ssl = false
 
 [logging]
 level = "DEBUG"
-responses = true # Global setting - don't log responses by default
-question = true  # Global setting - don't log questions by default
 
-# User-specific settings
-#users.rolivier = { responses = true, question = true }
+[logging.audit]
+enabled = true

--- a/data/release/selinux/clad.fc
+++ b/data/release/selinux/clad.fc
@@ -8,6 +8,3 @@
 # Data directory
 /var/lib/command-line-assistant(/.*)?             gen_context(system_u:object_r:clad_var_lib_t,s0)
 /var/lib/command-line-assistant/history.db     -- gen_context(system_u:object_r:clad_var_lib_t,s0)
-
-# Log files
-/var/log/command-line-assistant/audit.log      -- gen_context(system_u:object_r:clad_log_t,s0)

--- a/data/release/xdg/config.toml
+++ b/data/release/xdg/config.toml
@@ -65,11 +65,8 @@ verify_ssl = true
 [logging]
 # The default logging level for all messages logged by CLAD.
 level = "INFO"
-# Global setting to enable logging responses in an audit file and journald
-responses = false
-# Global setting to enable logging question in an audit file and journald
-question = false # Global setting - don't log questions by default
 
-# User-specific settings that can override the global settings based on user name.
-# Note: The user must exist in order for this to work.
-# users.admin = { responses = true, question = true }
+# Audit logging settings
+[logging.audit]
+# If enabled, we will log audit tracing to journald.
+enabled = false

--- a/packaging/command-line-assistant.spec
+++ b/packaging/command-line-assistant.spec
@@ -10,7 +10,6 @@ restorecon -R /etc/xdg/command-line-assistant/config.toml; \
 restorecon -R /etc/xdg/command-line-assistant; \
 restorecon -R /var/lib/command-line-assistant; \
 restorecon -R /var/log/command-line-assistant; \
-restorecon -R /var/log/command-line-assistant/audit.log; \
 
 %define selinux_policyver 41.27-1
 

--- a/tests/config/schemas/test_logging.py
+++ b/tests/config/schemas/test_logging.py
@@ -10,13 +10,3 @@ def test_logging_schema_invalid_level():
         ValueError, match="The requested level 'NOT_FOUND' is not allowed."
     ):
         LoggingSchema(level=level)
-
-
-def test_logging_user_not_in_system():
-    with pytest.raises(
-        ValueError,
-        match="test is not present on the system. Remove it from the configuration.",
-    ):
-        LoggingSchema(
-            level="INFO", users={"test": {"response": True, "question": True}}
-        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,13 +17,12 @@ from tests.helpers import MockStream
 
 
 @pytest.fixture(autouse=True)
-def setup_logger(tmp_path, request):
+def setup_logger(request):
     # This makes it so we can skip this using @pytest.mark.noautofixtures
     if "noautofixtures" in request.keywords:
         return
 
     logging_configuration = copy.deepcopy(LOGGING_CONFIG_DICTIONARY)
-    logging_configuration["handlers"]["audit_file"]["filename"] = tmp_path / "audit.log"
     with patch(
         "command_line_assistant.logger.LOGGING_CONFIG_DICTIONARY", logging_configuration
     ):
@@ -72,7 +71,6 @@ def mock_config(tmp_path):
             database=DatabaseSchema(type="sqlite", connection_string=history_db),
             logging=LoggingSchema(
                 level="debug",
-                users={"testuser": {"question": True, "responses": False}},
             ),
         )
 

--- a/tests/daemon/http/test_query.py
+++ b/tests/daemon/http/test_query.py
@@ -48,9 +48,8 @@ def test_disable_ssl_verification(caplog, default_payload, mock_config):
     responses.post(url="http://localhost/infer", json={"data": {"text": "yeah, test!"}})
 
     result = query.submit(default_payload, config=mock_config)
-
     assert result == "yeah, test!"
     assert (
         "Disabling SSL verification as per user requested."
-        in caplog.records[-1].message
+        in caplog.records[-2].message
     )

--- a/tests/dbus/interfaces/test_chat.py
+++ b/tests/dbus/interfaces/test_chat.py
@@ -71,7 +71,7 @@ def test_delete_all_chat_for_user(chat_interface, mock_repository, caplog):
     mock_repository.insert({"name": "test", "description": "test", "user_id": uid})
     chat_interface.DeleteAllChatForUser(uid)
 
-    assert f"for user '{uid}" in caplog.records[-1].message
+    assert "Deleting chat for user." in caplog.records[-1].message
 
 
 def test_delete_all_chat_for_user_no_chat(chat_interface):
@@ -85,7 +85,7 @@ def test_delete_chat_for_user(chat_interface, mock_repository, caplog):
     mock_repository.insert({"name": "test", "description": "test", "user_id": uid})
     chat_interface.DeleteChatForUser(uid, "test")
 
-    assert f"for user '{uid}'. Deleteing it as requested." in caplog.records[-1].message
+    assert "Deleting the request chat for user." in caplog.records[-1].message
 
 
 def test_delete_chat_for_user_exception(chat_interface):
@@ -127,6 +127,6 @@ def test_get_chat_id_exception(chat_interface):
 
 def test_create_chat(chat_interface, caplog):
     uid = "2345f9e6-dfea-11ef-9ae9-52b437312584"
-    chat_interface.CreateChat(uid, "test", "test")
-
-    assert "New chat session created" in caplog.records[-1].message
+    result = chat_interface.CreateChat(uid, "test", "test")
+    assert result
+    assert "-" in result

--- a/tests/dbus/interfaces/test_history.py
+++ b/tests/dbus/interfaces/test_history.py
@@ -158,7 +158,7 @@ def test_history_interface_clear_history(history_interface, caplog):
     with patch("command_line_assistant.dbus.interfaces.history.HistoryManager"):
         uid = "1710e580-dfce-11ef-a98f-52b437312584"
         history_interface.ClearHistory(uid)
-        assert f"Clearing history entries for user '{uid}'" in caplog.records[0].message
+        assert "Clearing history entries for user." in caplog.records[0].message
 
 
 def test_history_interface_empty_history(mock_history_entry, history_interface):
@@ -185,6 +185,5 @@ def test_write_history(history_interface, caplog):
         history_interface.WriteHistory(uid, uid, "test", "test")
 
     assert (
-        f"Wrote a new entry to the user history for user '{uid}' in chat '{uid}'."
-        in caplog.records[-1].message
+        "Wrote a new entry to the user history for user." in caplog.records[-1].message
     )

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from command_line_assistant.constants import VERSION
 from command_line_assistant.initialize import initialize
 from command_line_assistant.utils.cli import BaseCLICommand
 
@@ -71,15 +72,17 @@ def test_initialize_with_history_command():
         mock_command.assert_called_once()
 
 
-def test_initialize_with_version():
+def test_initialize_with_version(capsys):
     """Test initialize with --version flag"""
     with (
         patch("sys.argv", ["c", "--version"]),
         patch("command_line_assistant.initialize.read_stdin", lambda: None),
-        patch("argparse.ArgumentParser.exit") as mock_exit,
     ):
-        initialize()
-        mock_exit.assert_called_once()
+        with pytest.raises(SystemExit):
+            initialize()
+
+        captured = capsys.readouterr()
+        assert VERSION in captured.out
 
 
 def test_initialize_with_help(capsys):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -5,20 +5,15 @@ from unittest.mock import patch
 import pytest
 
 from command_line_assistant.logger import (
+    EXTRAS_TO_SKIP,
+    AuditFilter,
     AuditFormatter,
-    _create_audit_formatter,
-    _should_log_for_user,
+    NonAuditFilter,
     setup_logging,
 )
 
 
-@pytest.fixture
-def audit_formatter(mock_config):
-    """Create an AuditFormatter instance."""
-    return AuditFormatter(config=mock_config)
-
-
-def test_audit_formatter_format(audit_formatter):
+def test_audit_formatter_format():
     """Test basic formatting of log records."""
     record = logging.LogRecord(
         name="test",
@@ -29,20 +24,54 @@ def test_audit_formatter_format(audit_formatter):
         args=(),
         exc_info=None,
     )
-    record.user = "testuser"
+    record.user_id = "1000"
 
+    audit_formatter = AuditFormatter()
     formatted = audit_formatter.format(record)
     data = json.loads(formatted)
 
-    assert "timestamp" in data
-    assert data["user"] == "testuser"
-    assert data["message"] == "Test message"
-    assert data["query"] is None
-    assert data["response"] is None
+    required_fields = [
+        "priority",
+        "message",
+        "timestamp",
+        "syslog_identifier",
+        "code",
+        "user_id",
+        "audit_type",
+        "level",
+    ]
+    for field in required_fields:
+        assert field in data
 
 
-def test_audit_formatter_with_query_and_response(audit_formatter):
-    """Test formatting with query and response fields."""
+@pytest.mark.parametrize(
+    ("levelno", "expected"),
+    (
+        (50, 2),
+        (40, 3),
+        (30, 4),
+        (20, 6),
+        (10, 7),
+        (100, 6),  # default to info
+    ),
+)
+def test_get_syslog_priority_audit_formatter(levelno, expected):
+    audit_formatter = AuditFormatter()
+    assert audit_formatter._get_syslog_priority(levelno) == expected
+
+
+@pytest.mark.parametrize(
+    ("extras", "expected"),
+    (
+        ({"something": "yes"}, {"something": "yes"}),
+        ({"user_id": "yes"}, {}),
+        (
+            {"args": "test", "exc_info": "test"},
+            {},
+        ),  # Test that some of the EXTRAS_TO_SKIP will work correctly.
+    ),
+)
+def test_get_extra_fields(extras, expected):
     record = logging.LogRecord(
         name="test",
         level=logging.INFO,
@@ -52,21 +81,35 @@ def test_audit_formatter_with_query_and_response(audit_formatter):
         args=(),
         exc_info=None,
     )
-    record.user = "testuser"
-    record.query = "test query"
-    record.response = "test response"
 
-    formatted = audit_formatter.format(record)
-    data = json.loads(formatted)
+    for key, value in extras.items():
+        setattr(record, key, value)
 
-    assert data["query"] == "test query"
-    assert data["response"] == "test response"
+    audit_formatter = AuditFormatter()
+    result = audit_formatter._get_extra_fields(record)
+    assert result == expected
 
 
-def test_create_audit_formatter(mock_config):
-    """Test creation of audit formatter."""
-    formatter = _create_audit_formatter(mock_config)
-    assert isinstance(formatter, AuditFormatter)
+def test_get_extra_fields_with_skipping_values():
+    """All of the EXTRAS_TO_SKIP values should be skipped properly"""
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="Test message",
+        args=(),
+        exc_info=None,
+    )
+
+    record.blabla = "test"
+
+    for keys in EXTRAS_TO_SKIP:
+        setattr(record, keys, "test")
+
+    audit_formatter = AuditFormatter()
+    result = audit_formatter._get_extra_fields(record)
+    assert result == {"blabla": "test"}
 
 
 @patch("logging.config.dictConfig")
@@ -80,7 +123,7 @@ def test_setup_logging(mock_dict_config, mock_config):
 def test_audit_formatter_user_specific_logging(mock_config):
     """Test user-specific logging configuration."""
     # Configure mock for user-specific settings
-    formatter = AuditFormatter(config=mock_config)
+    formatter = AuditFormatter()
 
     record = logging.LogRecord(
         name="test",
@@ -91,16 +134,14 @@ def test_audit_formatter_user_specific_logging(mock_config):
         args=(),
         exc_info=None,
     )
-    record.user = "1000"
-    record.query = "test query"
-    record.response = "test response"
+    record.user_id = "1000"
+    record.something = "yes"
 
     formatted = formatter.format(record)
     data = json.loads(formatted)
-
-    # Query should be included but response should not for this user
-    assert data["query"] == "test query"
-    assert data["response"] is None
+    assert data["user_id"] == "1000"
+    assert "audit_data" in data
+    assert data["audit_data"]["something"] == "yes"
 
 
 def test_setup_logging_invalid_level(mock_config):
@@ -111,20 +152,36 @@ def test_setup_logging_invalid_level(mock_config):
 
 
 @pytest.mark.parametrize(
-    ("users", "effective_user_id", "log_type", "expected"),
-    (
-        ({"1000": {"response": True, "question": False}}, 1000, "response", True),
-        ({"1000": {"response": False, "question": False}}, 1000, "response", False),
-        ({"1000": {"response": False, "question": True}}, 1000, "question", True),
-        ({"1000": {"response": False, "question": False}}, 1000, "question", False),
-        # User is defined in the config, but nothing is specified
-        ({"1000": {}}, 1000, "question", False),
-        ({"1000": {}}, 1000, "response", False),
-        ({"1000": {}, "1001": {"response": True}}, 1001, "response", True),
-        ({"1000": {}, "1001": {"question": True}}, 1001, "question", True),
-        ({"1000": {}, "1001": {}}, 1001, "question", False),
-    ),
+    ("audit", "expected"), ((True, True), (False, False), (None, False))
 )
-def test_should_log_for_user(users, effective_user_id, log_type, expected, mock_config):
-    mock_config.logging.users = users
-    assert _should_log_for_user(effective_user_id, mock_config, log_type) == expected
+def test_audit_filter(audit, expected):
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="Test message",
+        args=(),
+        exc_info=None,
+    )
+    record.audit = audit
+
+    assert AuditFilter().filter(record) == expected
+
+
+@pytest.mark.parametrize(
+    ("audit", "expected"), ((True, False), (False, True), (None, True))
+)
+def test_non_audit_filter(audit, expected):
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="Test message",
+        args=(),
+        exc_info=None,
+    )
+    record.audit = audit
+
+    assert NonAuditFilter().filter(record) == expected

--- a/tests/utils/test_cli.py
+++ b/tests/utils/test_cli.py
@@ -127,8 +127,9 @@ def test_add_default_command(args, stdin, expected):
     ("argv", "expected"),
     (
         (["chat"], "chat"),
-        (["--version"], "--version"),
-        (["--help"], "--help"),
+        (["--debug"], None),
+        (["--version"], None),
+        (["--help"], None),
         (["--clear"], None),
     ),
 )


### PR DESCRIPTION
Rework the audit logging system to be less complex and accept dynamic attributes to be recorded.

Not all the database is set to use it, but the parts that are (chat and some history) are already working with it.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-573](https://issues.redhat.com/browse/RSPEED-573)
- [RSPEED-577](https://issues.redhat.com/browse/RSPEED-577)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
