### PR TITLE
[RSPEED-586] Add a new shell command to handle integrations

### DIFF
--- a/command_line_assistant/commands/shell.py
+++ b/command_line_assistant/commands/shell.py
@@ -1,0 +1,167 @@
+"""Module to handle the history command."""
+
+import logging
+from argparse import Namespace
+from pathlib import Path
+
+from command_line_assistant.dbus.exceptions import (
+    ChatNotFoundError,
+    CorruptedHistoryError,
+    HistoryNotAvailable,
+    MissingHistoryFileError,
+)
+from command_line_assistant.integrations import BASH_INTERACTIVE
+from command_line_assistant.rendering.renders.text import TextRenderer
+from command_line_assistant.utils.cli import BaseCLICommand, SubParsersAction
+from command_line_assistant.utils.renderers import (
+    create_error_renderer,
+    create_text_renderer,
+    create_warning_renderer,
+)
+
+#: The path to bashrc.d folder
+BASH_RC_D_PATH: Path = Path("~/.bashrc.d").expanduser()
+#: The complete path to the integration file.
+INTEGRATION_FILE: Path = Path(BASH_RC_D_PATH, "cla-interactive.bashrc")
+
+logger = logging.getLogger(__name__)
+
+
+class ShellCommand(BaseCLICommand):
+    """Class that represents the history command."""
+
+    def __init__(self, args: Namespace) -> None:
+        """Constructor of the class.
+
+        Note:
+            If none of the above is specified, the command will retrieve all
+            user history.
+
+        Arguments:
+            args (Namespace): The args for that command.
+        """
+        self._args = args
+
+        self._text_renderer: TextRenderer = create_text_renderer()
+        self._warning_renderer: TextRenderer = create_warning_renderer()
+        self._error_renderer: TextRenderer = create_error_renderer()
+
+        super().__init__()
+
+    def run(self) -> int:
+        """Main entrypoint for the command to run.
+
+        Returns:
+            int: Status code of the execution.
+        """
+        try:
+            if self._args.enable_integration:
+                return self._write_bash_functions()
+            elif self._args.disable_integration:
+                return self._remove_bash_functions()
+            return 0
+        except (
+            MissingHistoryFileError,
+            CorruptedHistoryError,
+            ChatNotFoundError,
+            HistoryNotAvailable,
+        ) as e:
+            self._error_renderer.render(str(e))
+            return 1
+
+    def _write_bash_functions(self) -> int:
+        """Internal method to handle the creation of the bash integration file.
+
+        Returns:
+            int: The status code of the operation
+        """
+
+        if not BASH_RC_D_PATH.exists():
+            try:
+                BASH_RC_D_PATH.mkdir(0o700)
+            except FileExistsError as e:
+                logger.debug(
+                    "While trying to create the bashrc.d folder, we got an exception '%s'.",
+                    str(e),
+                )
+
+        try:
+            INTEGRATION_FILE.write_text(BASH_INTERACTIVE)
+            INTEGRATION_FILE.chmod(0o600)
+            self._text_renderer.render(
+                f"Integration placed successfully at {INTEGRATION_FILE}"
+            )
+            return 0
+        except FileExistsError as e:
+            logger.debug(
+                "While trying to write the integration bashrc at '%s', we got the following exception: '%s'",
+                str(INTEGRATION_FILE),
+                str(e),
+            )
+            return 1
+
+    def _remove_bash_functions(self) -> int:
+        """Internal method to handle the removal of the bash integration file.
+
+        Returns:
+            int: The status code of the operation
+        """
+
+        if not INTEGRATION_FILE.exists():
+            logger.debug(
+                "Couldn't find integration file at '%s'", str(INTEGRATION_FILE)
+            )
+            self._text_renderer.render(
+                "It seems that the integration is not enabled. Skipping operation."
+            )
+            return 0
+
+        try:
+            INTEGRATION_FILE.unlink()
+            self._text_renderer.render("Integration disabled successfuly.")
+            return 0
+        except (FileExistsError, FileNotFoundError) as e:
+            logger.warning(
+                "Got an exception '%s'. Either file is missing or something removed just before this operation",
+                str(e),
+            )
+            return 1
+
+
+def register_subcommand(parser: SubParsersAction):
+    """
+    Register this command to argparse so it's available for the root parser.
+
+    Args:
+        parser (SubParsersAction): Root parser to register command-specific arguments
+    """
+    shell_parser = parser.add_parser(
+        "shell",
+        help="Manage shell integrations",
+    )
+    shell_parser.add_argument(
+        "-ei",
+        "--enable-integration",
+        action="store_true",
+        help="Enable the shell integrations on the system. Currently, only BASH is supported.",
+    )
+    shell_parser.add_argument(
+        "-di",
+        "--disable-integration",
+        action="store_true",
+        help="Disable the shell integrations on the system.",
+    )
+
+    shell_parser.set_defaults(func=_command_factory)
+
+
+def _command_factory(args: Namespace) -> ShellCommand:
+    """Internal command factory to create the command class
+
+    Args:
+        args (Namespace): The arguments processed with argparse.
+
+    Returns:
+        ShellCommand: Return an instance of class
+    """
+    return ShellCommand(args)

--- a/command_line_assistant/initialize.py
+++ b/command_line_assistant/initialize.py
@@ -4,7 +4,7 @@ import logging
 import sys
 from argparse import ArgumentParser, Namespace
 
-from command_line_assistant.commands import chat, history
+from command_line_assistant.commands import chat, history, shell
 from command_line_assistant.logger import setup_logging
 from command_line_assistant.utils.cli import (
     add_default_command,
@@ -27,6 +27,7 @@ def register_subcommands() -> ArgumentParser:
     # and call `register_subcommand()` on each one.
     chat.register_subcommand(commands_parser)  # type: ignore
     history.register_subcommand(commands_parser)  # type: ignore
+    shell.register_subcommand(commands_parser)  # type: ignore
 
     return parser
 
@@ -59,6 +60,7 @@ def initialize() -> int:
         # In case the uder specify the --debug, we will enable the logging here.
         if args.debug:
             setup_logging()
+
         service = args.func(args)
         return service.run()
     except ValueError as e:

--- a/command_line_assistant/integrations.py
+++ b/command_line_assistant/integrations.py
@@ -1,0 +1,38 @@
+"""Hold any shell integration that powers the tool."""
+
+#: Bash interactive session for c.
+BASH_INTERACTIVE: str = r"""\
+# Command Line Assistant Interactive Mode Integration
+c_interactive() {
+    # Save current terminal state
+    local old_tty=$(stty -g)
+    local c_binary=/usr/bin/c
+
+    # Function to restore terminal state
+    cleanup() {
+        stty "$old_tty"
+    }
+
+    # Set cleanup on exit
+    trap cleanup EXIT
+
+    # Configure terminal for interactive input
+    stty sane  # Reset terminal to sane state
+    stty echo  # Ensure input is echoed (visible)
+    stty icanon # Enable canonical mode (line-by-line input)
+
+    # Start interactive mode
+    if command -v $c_binary >/dev/null 2>&1; then
+        $c_binary --interactive
+    else
+        echo "Error: Command Line Assistant is not installed"
+        return 1
+    fi
+
+    # Explicitly restore terminal state after c --interactive exits
+    cleanup
+}
+
+# Bind Ctrl+J to the interactive function
+bind -x '"\C-j": c_interactive'
+"""

--- a/command_line_assistant/utils/cli.py
+++ b/command_line_assistant/utils/cli.py
@@ -118,7 +118,7 @@ def _subcommand_used(args: list[str]) -> Optional[str]:
             continue
 
         # If we have a exact match for any of the commands, return directly
-        if argument in ("chat", "history"):
+        if argument in ("chat", "history", "shell"):
             return argument
 
         # Otherwise, check if this is the second part of an arg that takes a value.

--- a/command_line_assistant/utils/environment.py
+++ b/command_line_assistant/utils/environment.py
@@ -5,11 +5,14 @@ Utilitary module to interact with environment variables.
 import os
 from pathlib import Path
 
-# The wanted xdg path where the configuration files will live.
+#: The wanted xdg path where the configuration files will live.
 WANTED_XDG_PATH = Path("/etc/xdg")
 
-# The wanted xdg state path in case $XDG_STATE_HOME is not defined.
+#: The wanted xdg state path in case $XDG_STATE_HOME is not defined.
 WANTED_XDG_STATE_PATH = Path("~/.local/state").expanduser()
+
+#: The wanted xdg data path in case $XDG_DATA_HOME is not defined.
+WANTED_XDG_DATA_PATH = Path("~/.local/share").expanduser()
 
 
 def get_xdg_state_path() -> Path:
@@ -27,6 +30,21 @@ def get_xdg_state_path() -> Path:
     return (
         Path(xdg_state_home).expanduser() if xdg_state_home else WANTED_XDG_STATE_PATH
     )
+
+
+def get_xdg_data_path() -> Path:
+    """Check for the existence of XDG_DATA_HOME environment variable.
+
+    In case it is not present, this function will return the default path that
+    is `~/.local/share`, which is where we want to place data files for
+    Command Line Assistant.
+
+    See: https://specifications.freedesktop.org/basedir-spec/latest/
+    """
+    xdg_data_home = os.getenv("XDG_DATA_HOME", "")
+
+    # We call expanduser() for the xdg_data_home in case someone do "~/"
+    return Path(xdg_data_home).expanduser() if xdg_data_home else WANTED_XDG_DATA_PATH
 
 
 def get_xdg_config_path() -> Path:

--- a/data/release/man/c.1
+++ b/data/release/man/c.1
@@ -27,22 +27,24 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "C" "1" "Feb 03, 2025" "0.1.0" "Command Line Assistant"
+.TH "C" "1" "Feb 05, 2025" "0.1.0" "Command Line Assistant"
 .SH NAME
 c \- Command Line Assistant Client
 .SH SYNOPSIS
 .sp
-The Command Line Assistant powered by RHEL Lightspeed is a optional generative AI assistant available within the RHEL command line interface.
+The Command Line Assistant powered by RHEL Lightspeed is an optional generative AI assistant available within the RHEL command line interface.
 .INDENT 0.0
 .INDENT 3.5
 .sp
 .EX
-c [\-h] [\-v] {chat,history} ...
+c [\-\-debug] [\-h] [\-v] {chat,history,shell} ...
 .EE
 .UNINDENT
 .UNINDENT
 .SS c options
 .INDENT 0.0
+.IP \(bu 2
+\fI\%\-\-debug\fP \- Enable debug logging information
 .IP \(bu 2
 \fI\%\-h\fP, \fI\%\-\-help\fP \- Show this help message and exit.
 .IP \(bu 2
@@ -118,6 +120,26 @@ c history [\-h] [\-f] [\-l] [\-fi FILTER] [\-c]
 .IP \(bu 2
 \fI\%\-c\fP, \fI\%\-\-clear\fP \- Clear the entire history. If no \-\-from is specified, it will clear all history from all chats.
 .UNINDENT
+.SS c shell
+.sp
+Manage shell integrations
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.EX
+c shell [\-h] [\-ei] [\-di]
+.EE
+.UNINDENT
+.UNINDENT
+.SS c shell options
+.INDENT 0.0
+.IP \(bu 2
+\fI\%\-h\fP, \fI\%\-\-help\fP \- show this help message and exit
+.IP \(bu 2
+\fI\%\-ei\fP, \fI\%\-\-enable\-integration\fP \- Enable the shell integrations on the system. Currently, only BASH is supported.
+.IP \(bu 2
+\fI\%\-di\fP, \fI\%\-\-disable\-integration\fP \- Disable the shell integrations on the system.
+.UNINDENT
 .SH DESCRIPTION
 .sp
 The Command Line Assistant powered by RHEL Lightspeed is an optional generative
@@ -137,6 +159,12 @@ Assistant can help with several tasks such as:
 .sp
 The Command Line Assistant provides a natural language interface, and can
 incorporate information from resources such as the RHEL documentation.
+.SH FILES
+.INDENT 0.0
+.TP
+.B \fI~/.bashrc.d/cla\-interactive.bashrc\fP
+Bash script to add keyboard binding to enable interactive mode.
+.UNINDENT
 .SH EXAMPLES
 .sp
 Example 1. Asking a simple question
@@ -321,6 +349,48 @@ And finally, to start a clean history, you can clear all the user history with:
 .sp
 .EX
 $ c history \-\-clear
+.EE
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.UNINDENT
+.sp
+Example 5. Shell integrations
+.INDENT 0.0
+.INDENT 3.5
+With Command Line Assistant, you can also enable shell integrations to help
+in your experience:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.EX
+$ c shell \-\-enable\-integration
+.EE
+.UNINDENT
+.UNINDENT
+.sp
+The above command will place a file under ~/.bashrc.d folder that will
+be sourced by bash after the next time you open up your terminal.
+Currently, we only have one integration that aims to start the
+interactive mode with a keybind, like the following:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.EX
+$ c shell \-\-enable\-integration
+# After enabling the integration, restart your terminal or run
+$ source ~/.bashrc
+# After the integration was sourced, you can hit Ctrl + J in your terminal to enable interactive mode.
+.EE
+.UNINDENT
+.UNINDENT
+.sp
+If you wish to disable the integration, that can be done with:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.EX
+$ c shell \-\-disabled\-integration
 .EE
 .UNINDENT
 .UNINDENT

--- a/data/release/man/clad.8
+++ b/data/release/man/clad.8
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "CLAD" "8" "Feb 03, 2025" "0.1.0" "Command Line Assistant"
+.TH "CLAD" "8" "Feb 05, 2025" "0.1.0" "Command Line Assistant"
 .SH NAME
 clad \- Command Line Assistant Daemon
 .SH SYNOPSIS

--- a/docs/source/commands/index.rst
+++ b/docs/source/commands/index.rst
@@ -5,4 +5,5 @@ Commands
    :maxdepth: 2
 
    chat
+   shell
    history

--- a/docs/source/commands/shell.rst
+++ b/docs/source/commands/shell.rst
@@ -1,0 +1,8 @@
+Shell Command
+=============
+
+.. automodule:: command_line_assistant.commands.shell
+   :members:
+   :undoc-members:
+   :private-members:
+   :no-index:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ Welcome to Command Line Assistant documentation
    logger
    meta
    exceptions
+   integrations
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/integrations.rst
+++ b/docs/source/integrations.rst
@@ -1,0 +1,8 @@
+Integrations
+============
+
+.. automodule:: command_line_assistant.integrations
+   :members:
+   :undoc-members:
+   :private-members:
+   :no-index:

--- a/docs/source/man/command-line-assistant.1.rst
+++ b/docs/source/man/command-line-assistant.1.rst
@@ -114,6 +114,28 @@ Example 4. History management
 
         $ c history --clear
 
+Example 5. Shell integrations
+
+    With Command Line Assistant, you can also enable shell integrations to help
+    in your experience::
+
+        $ c shell --enable-integration
+
+
+    The above command will place a file under ~/.bashrc.d folder that will
+    be sourced by bash after the next time you open up your terminal.
+    Currently, we only have one integration that aims to start the
+    interactive mode with a keybind, like the following::
+
+        $ c shell --enable-integration
+        # After enabling the integration, restart your terminal or run
+        $ source ~/.bashrc
+        # After the integration was sourced, you can hit Ctrl + J in your terminal to enable interactive mode.
+
+    If you wish to disable the integration, that can be done with::
+
+        $ c shell --disabled-integration
+
 Notes
 -----
 
@@ -128,6 +150,12 @@ order to maintain a correct order of querying. The rules can be seen here::
     5. Stdin + file query -> combine as "{stdin} {file_query}"
     6. Positional + file query -> combine as "{positional_query} {file_query}"
     7. All three sources -> use only positional and file as "{positional_query} {file_query}"
+
+Files
+-----
+
+*~/.bashrc.d/cla-interactive.bashrc*
+    Bash script to add keyboard binding to enable interactive mode.
 
 Reference
 ---------

--- a/poetry.lock
+++ b/poetry.lock
@@ -874,6 +874,35 @@ typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.1
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
+name = "ruff"
+version = "0.9.4"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"dev\""
+files = [
+    {file = "ruff-0.9.4-py3-none-linux_armv6l.whl", hash = "sha256:64e73d25b954f71ff100bb70f39f1ee09e880728efb4250c632ceed4e4cdf706"},
+    {file = "ruff-0.9.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6ce6743ed64d9afab4fafeaea70d3631b4d4b28b592db21a5c2d1f0ef52934bf"},
+    {file = "ruff-0.9.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:54499fb08408e32b57360f6f9de7157a5fec24ad79cb3f42ef2c3f3f728dfe2b"},
+    {file = "ruff-0.9.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37c892540108314a6f01f105040b5106aeb829fa5fb0561d2dcaf71485021137"},
+    {file = "ruff-0.9.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:de9edf2ce4b9ddf43fd93e20ef635a900e25f622f87ed6e3047a664d0e8f810e"},
+    {file = "ruff-0.9.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87c90c32357c74f11deb7fbb065126d91771b207bf9bfaaee01277ca59b574ec"},
+    {file = "ruff-0.9.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:56acd6c694da3695a7461cc55775f3a409c3815ac467279dfa126061d84b314b"},
+    {file = "ruff-0.9.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e0c93e7d47ed951b9394cf352d6695b31498e68fd5782d6cbc282425655f687a"},
+    {file = "ruff-0.9.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1d4c8772670aecf037d1bf7a07c39106574d143b26cfe5ed1787d2f31e800214"},
+    {file = "ruff-0.9.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfc5f1d7afeda8d5d37660eeca6d389b142d7f2b5a1ab659d9214ebd0e025231"},
+    {file = "ruff-0.9.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:faa935fc00ae854d8b638c16a5f1ce881bc3f67446957dd6f2af440a5fc8526b"},
+    {file = "ruff-0.9.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a6c634fc6f5a0ceae1ab3e13c58183978185d131a29c425e4eaa9f40afe1e6d6"},
+    {file = "ruff-0.9.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:433dedf6ddfdec7f1ac7575ec1eb9844fa60c4c8c2f8887a070672b8d353d34c"},
+    {file = "ruff-0.9.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d612dbd0f3a919a8cc1d12037168bfa536862066808960e0cc901404b77968f0"},
+    {file = "ruff-0.9.4-py3-none-win32.whl", hash = "sha256:db1192ddda2200671f9ef61d9597fcef89d934f5d1705e571a93a67fb13a4402"},
+    {file = "ruff-0.9.4-py3-none-win_amd64.whl", hash = "sha256:05bebf4cdbe3ef75430d26c375773978950bbf4ee3c95ccb5448940dc092408e"},
+    {file = "ruff-0.9.4-py3-none-win_arm64.whl", hash = "sha256:585792f1e81509e38ac5123492f8875fbc36f3ede8185af0a26df348e5154f41"},
+    {file = "ruff-0.9.4.tar.gz", hash = "sha256:6907ee3529244bb0ed066683e075f09285b38dd5b4039370df6ff06041ca19e7"},
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.37"
 description = "Database Abstraction Library"
@@ -1132,10 +1161,10 @@ type = ["pytest-mypy"]
 
 [extras]
 db = ["mysqlclient", "psycopg2"]
-dev = ["PyGObject"]
+dev = ["PyGObject", "ruff"]
 tests = ["coverage", "pytest", "pytest-clarity", "pytest-cov", "pytest-randomly", "pytest-sugar", "responses", "tox"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "fe56446bd69ba35079d62f240c98f8956d2e3023a80ca46e54e252eeabc8e354"
+content-hash = "8bfd6dffa35e176c0018af83bcd41c6ecbbf2c70e25ebcec345f79b52e33473e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,11 @@ tests = [
     "tox>=4.23.2",
     "responses>=0.25.3",
 ]
-dev = ["PyGObject>=3.50.0"]
+dev = [
+    "PyGObject>=3.50.0",
+    # added here mainly for editor happines
+    "ruff>=0.9.4"
+]
 
 # ----- Tooling specifics
 [tool.setuptools.packages.find]

--- a/tests/commands/test_shell.py
+++ b/tests/commands/test_shell.py
@@ -1,0 +1,98 @@
+from argparse import ArgumentParser, Namespace
+
+import pytest
+
+from command_line_assistant.commands import shell
+from command_line_assistant.commands.shell import (
+    ShellCommand,
+    _command_factory,
+    register_subcommand,
+)
+
+
+@pytest.fixture
+def default_namespace():
+    return Namespace(enable_integration=None, disable_integration=None)
+
+
+@pytest.fixture(autouse=True)
+def mock_bashrc_d_path(tmp_path, monkeypatch):
+    bash_rc_d = tmp_path / ".bashrc.d"
+    integration_file = bash_rc_d / "cla-interactive.bashrc"
+    monkeypatch.setattr(shell, "BASH_RC_D_PATH", bash_rc_d)
+    monkeypatch.setattr(shell, "INTEGRATION_FILE", integration_file)
+
+
+def test_shell_command_initialization(default_namespace):
+    """Test QueryCommand initialization"""
+    default_namespace.enable_integration = True
+    command = ShellCommand(default_namespace)
+    assert command._args == default_namespace
+
+
+def test_register_subcommand():
+    """Test register_subcommand function"""
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers()
+
+    # Register the subcommand
+    register_subcommand(subparsers)
+
+    # Parse a test command
+    args = parser.parse_args(["shell", "--enable-integration"])
+
+    assert args.enable_integration
+    assert hasattr(args, "func")
+
+
+def test_command_factory(default_namespace):
+    """Test _command_factory function"""
+    default_namespace.enable_integration = True
+    command = _command_factory(default_namespace)
+
+    assert isinstance(command, ShellCommand)
+    assert command._args.enable_integration
+
+
+def test_shell_command_enable_integration(capsys, default_namespace):
+    """Test QueryCommand run method with different inputs"""
+    default_namespace.enable_integration = True
+    command = ShellCommand(default_namespace)
+    assert command.run() == 0
+
+    # Verify output was printed
+    captured = capsys.readouterr()
+    assert "Integration placed successfully" in captured.out
+
+
+def test_shell_command_disable_integration(capsys, default_namespace, tmp_path):
+    default_namespace.disable_integration = True
+    bash_rc_d = tmp_path / ".bashrc.d"
+    integration_file = bash_rc_d / "cla-interactive.bashrc"
+    bash_rc_d.mkdir()
+    integration_file.write_text("hi!")
+    command = ShellCommand(default_namespace)
+    assert command.run() == 0
+
+    # Verify output was printed
+    captured = capsys.readouterr()
+    assert "Integration disabled successfuly." in captured.out
+
+
+def test_shell_command_enable_integration_file_already_exists(
+    capsys, default_namespace, tmp_path, monkeypatch
+):
+    bash_rc_d = tmp_path / ".bashrc.d"
+    integration_file = bash_rc_d / "cla-interactive.bashrc"
+    monkeypatch.setattr(shell, "BASH_RC_D_PATH", bash_rc_d)
+    monkeypatch.setattr(shell, "INTEGRATION_FILE", integration_file)
+    bash_rc_d.mkdir()
+    integration_file.write_text("hi!")
+
+    default_namespace.enable_integration = True
+    command = ShellCommand(default_namespace)
+    assert command.run() == 0
+
+    # Verify output was printed
+    captured = capsys.readouterr()
+    assert "Integration is already present" in captured.err

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -72,6 +72,25 @@ def test_initialize_with_history_command():
         mock_command.assert_called_once()
 
 
+def test_initialize_with_shell_command():
+    """Test initialize with shell command"""
+    mock_command = Mock(return_value=MockCommand())
+
+    with (
+        patch("sys.argv", ["c", "shell", "--enable-integration"]),
+        patch("command_line_assistant.commands.chat.register_subcommand"),
+        patch("command_line_assistant.commands.history.register_subcommand"),
+        patch("command_line_assistant.commands.shell.register_subcommand"),
+        patch("command_line_assistant.initialize.read_stdin", lambda: None),
+        patch("argparse.ArgumentParser.parse_args") as mock_parse,
+    ):
+        mock_parse.return_value.func = mock_command
+        result = initialize()
+
+        assert result == 1
+        mock_command.assert_called_once()
+
+
 def test_initialize_with_version(capsys):
     """Test initialize with --version flag"""
     with (
@@ -116,6 +135,7 @@ def test_initialize_bad_stdin(capsys):
         (["c"], "chat"),  # Default to chat
         (["c", "chat"], "chat"),
         (["c", "history"], "history"),
+        (["c", "shell"], "shell"),
     ],
 )
 def test_initialize_command_selection(argv, expected_command):

--- a/tests/utils/test_cli.py
+++ b/tests/utils/test_cli.py
@@ -116,6 +116,7 @@ def test_create_argument_parser():
         ),
         (["/usr/bin/c", "test query"], None, ["chat", "test query"]),
         (["/usr/bin/c", "history"], None, ["history"]),
+        (["/usr/bin/c", "shell"], None, ["shell"]),
     ],
 )
 def test_add_default_command(args, stdin, expected):

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -32,3 +32,17 @@ def test_get_xdg_state_path(xdg_path_env, expected, monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(environment, "WANTED_XDG_STATE_PATH", Path("some/dir"))
     monkeypatch.setenv("XDG_STATE_HOME", xdg_path_env)
     assert environment.get_xdg_state_path() == expected
+
+
+@pytest.mark.parametrize(
+    ("xdg_path_env", "expected"),
+    (
+        ("", Path("some/dir")),
+        ("/etc/xdg", Path("/etc/xdg")),
+        ("/my-special-one-path", Path("/my-special-one-path")),
+    ),
+)
+def test_get_xdg_data_path(xdg_path_env, expected, monkeypatch):
+    monkeypatch.setattr(environment, "WANTED_XDG_DATA_PATH", Path("some/dir"))
+    monkeypatch.setenv("XDG_DATA_HOME", xdg_path_env)
+    assert environment.get_xdg_data_path() == expected


### PR DESCRIPTION
Added a new shell command option to enable and disable shell
integrations. This command will hold, for now, the modifications that we
need to do in the user shell/terminal.

Currently, we only have one integration to control, which is the key
binding for the interactive mode.


<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-586](https://issues.redhat.com/browse/RSPEED-586)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
