### PR TITLE
Reverse order of the terminal output reader

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -550,7 +550,7 @@ def register_subcommand(parser: SubParsersAction) -> None:
         help="Command to ask a question to the LLM.",
     )
 
-    question_group = chat_parser.add_argument_group("Question options")
+    question_group = chat_parser.add_argument_group("Question Options")
     # Positional argument, required only if no optional arguments are provided
     question_group.add_argument(
         "query_string", nargs="?", help="The question that will be sent to the LLM"
@@ -569,16 +569,17 @@ def register_subcommand(parser: SubParsersAction) -> None:
         help="Start interactive chat session",
     )
     question_group.add_argument(
-        "-lo",
-        "--last-output",
+        "-o",
+        "--with-output",
         nargs="?",
         type=int,
         # In case nothing is supplied
-        const=-1,
+        const=1,
+        default=1,
         help="Read last output from terminal. Default to last entry collected.",
     )
 
-    chat_arguments = chat_parser.add_argument_group("Chat options")
+    chat_arguments = chat_parser.add_argument_group("Chat Options")
     chat_arguments.add_argument(
         "-l", "--list", action="store_true", help="List all chats"
     )
@@ -590,7 +591,7 @@ def register_subcommand(parser: SubParsersAction) -> None:
         help="Delete a chat session",
     )
     chat_arguments.add_argument(
-        "-da", "--delete-all", action="store_true", help="Delete all chats"
+        "--delete-all", action="store_true", help="Delete all chats"
     )
     chat_arguments.add_argument(
         "-n",

--- a/command_line_assistant/commands/history.py
+++ b/command_line_assistant/commands/history.py
@@ -247,7 +247,6 @@ def register_subcommand(parser: SubParsersAction):
         help="Get the last conversation from history.",
     )
     filtering_options.add_argument(
-        "-fi",
         "--filter",
         help="Search for a specific keyword of text in the history.",
     )

--- a/command_line_assistant/commands/shell.py
+++ b/command_line_assistant/commands/shell.py
@@ -211,19 +211,16 @@ def register_subcommand(parser: SubParsersAction):
 
     terminal_capture_group = shell_parser.add_argument_group("Terminal Capture Options")
     terminal_capture_group.add_argument(
-        "-ec",
         "--enable-capture",
         action="store_true",
         help="Enable terminal capture for the current terminal session.",
     )
     terminal_capture_group.add_argument(
-        "-epc",
         "--enable-persistent-capture",
         action="store_true",
         help="Enable persistent terminal capture for the terminal session.",
     )
     terminal_capture_group.add_argument(
-        "-dpc",
         "--disable-persistent-capture",
         action="store_true",
         help="Disable persistent terminal capture for the terminal session.",
@@ -231,13 +228,11 @@ def register_subcommand(parser: SubParsersAction):
 
     interactive_mode = shell_parser.add_argument_group("Interactive Mode Options")
     interactive_mode.add_argument(
-        "-ei",
         "--enable-interactive",
         action="store_true",
         help="Enable the shell integration for interactive mode on the system. Currently, only BASH is supported.",
     )
     interactive_mode.add_argument(
-        "-di",
         "--disable-interactive",
         action="store_true",
         help="Disable the shell integrationfor interactive mode on the system.",

--- a/command_line_assistant/terminal/parser.py
+++ b/command_line_assistant/terminal/parser.py
@@ -17,8 +17,8 @@ def parse_terminal_output() -> list[dict[str, str]]:
     """Parse collected terminal output.
 
     Returns:
-        list[dict[str, str]]: A list containing the parsed data. If no file was found, we
-        just return empty list.
+        list[dict[str, str]]: A reversed list containing the parsed data. If no
+        file was found, we just return empty list.
     """
     result = []
 
@@ -45,6 +45,8 @@ def parse_terminal_output() -> list[dict[str, str]]:
                 return result
 
     logger.debug("Final result json list: %s", result)
+    # Reverse the list before returning
+    result.reverse()
     return result
 
 

--- a/command_line_assistant/terminal/reader.py
+++ b/command_line_assistant/terminal/reader.py
@@ -99,7 +99,10 @@ def start_capturing() -> None:
     os.environ["PROMPT_COMMAND"] = f"{user_prompt_command}{PROMPT_MARKER}"
 
     # Get the current user SHELL environment variable, if not set, use sh.
-    shell = os.environ.get("SHELL", "sh")
+    shell = os.environ.get("SHELL", "/usr/bin/sh")
+
+    # Set up proper shell environment variables for job control
+    os.environ["TERM"] = os.environ.get("TERM", "xterm")
 
     # The create_folder function will silently fail in case the folder exists.
     create_folder(OUTPUT_FILE_NAME.parent)
@@ -110,7 +113,7 @@ def start_capturing() -> None:
     with OUTPUT_FILE_NAME.open(mode="wb") as handler:
         # Instantiate the TerminalRecorder and spawn a new shell with pty.
         recorder = TerminalRecorder(handler)
-        pty.spawn(shell, recorder.read)
+        pty.spawn([shell, "-i", "--login"], recorder.read)
 
         # Write the final json block if it exists.
         recorder.write_json_block()


### PR DESCRIPTION
This patch aims in reversing the order of the last output read from the terminal to make the interface more friendly to the user. Instead of having to think about positive and negative number ordering (python indexes), they can just use positive number ordering and that will be translated internally to the list.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
