### PR TITLE
Update to push event for building manpages

### DIFF
--- a/.github/workflows/build-manpages.yaml
+++ b/.github/workflows/build-manpages.yaml
@@ -5,8 +5,8 @@
 name: "Build manpages"
 
 on:
-  pull_request:
-    types: ["labeled"]
+  push:
+    branches: ["release/v*"]
 
 permissions:
   contents: write
@@ -15,12 +15,10 @@ jobs:
   build:
     name: Build manpage
     runs-on: ubuntu-latest
-    if: ${{ github.event.label.name == 'manpages' }}
-
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.ref }}
 
       - uses: actions/setup-python@v5
 


### PR DESCRIPTION
This patch changes to a push event in order to build the manpages only when we push to the release branch. By default, we want to tag everytime from that branch, and not from main anymore.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
