### PR TITLE
[RSPEED-656] Non default value for with output

### DIFF
--- a/command_line_assistant/commands/base.py
+++ b/command_line_assistant/commands/base.py
@@ -196,7 +196,6 @@ class CommandOperationFactory:
             ),
             None,
         )
-
         if not operation_type:
             return None
 

--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -590,10 +590,7 @@ def register_subcommand(parser: SubParsersAction) -> None:
         "--with-output",
         nargs="?",
         type=int,
-        # In case nothing is supplied
-        const=1,
-        default=1,
-        help="Read last output from terminal. Default to last entry collected.",
+        help="Add output from terminal as context for the query. Use 0 to retrieve latest output.",
     )
     question_group.add_argument(
         "-r",


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-656](https://issues.redhat.com/browse/RSPEED-656)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
