### PR TITLE
Add a timing decorator to help understand slowness

### DIFF
--- a/command_line_assistant/initialize.py
+++ b/command_line_assistant/initialize.py
@@ -4,6 +4,8 @@ import logging
 import sys
 from argparse import ArgumentParser, Namespace
 
+from dasbus.error import DBusError
+
 from command_line_assistant.commands import chat, history, shell
 from command_line_assistant.logger import setup_client_logging
 from command_line_assistant.utils.cli import (
@@ -61,4 +63,10 @@ def initialize() -> int:
         return service.run()
     except ValueError as e:
         error_renderer.render(str(e))
+        return 1
+    except DBusError as e:
+        logger.error("Got exception from dbus: %s", str(e))
+        error_renderer.render(
+            f"Failed to communicate with daemon through dbus. Reason: {str(e)}"
+        )
         return 1

--- a/command_line_assistant/terminal/parser.py
+++ b/command_line_assistant/terminal/parser.py
@@ -27,7 +27,6 @@ def parse_terminal_output() -> list[dict[str, str]]:
 
     with OUTPUT_FILE_NAME.open(mode="r") as handler:
         for block in handler:
-            logger.debug("Parsing block %s", block)
             # Parse the JSON
             try:
                 parsed = json.loads(block)
@@ -44,7 +43,6 @@ def parse_terminal_output() -> list[dict[str, str]]:
                 )
                 return result
 
-    logger.debug("Final result json list: %s", result)
     # Reverse the list before returning
     result.reverse()
     return result
@@ -78,6 +76,5 @@ def clean_parsed_text(text: str) -> str:
         str: The cleaned string.
     """
     # Remove ANSI escape sequences
-    logger.info("Cleaning ANSI escape sequences with regex %s", ANSI_ESCAPE_SEQ)
     cleaned_ansi_escape_seq = ANSI_ESCAPE_SEQ.sub("", text)
     return cleaned_ansi_escape_seq.strip()

--- a/command_line_assistant/utils/benchmark.py
+++ b/command_line_assistant/utils/benchmark.py
@@ -1,0 +1,174 @@
+"""Module that holds the benchmark functions and metrics"""
+
+import json
+import logging
+import time
+from functools import wraps
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class TimingLogger:
+    """Specialized logger class for timing function execution.
+
+    This class provides detailed timing information for function calls, including:
+    - Function name and arguments
+    - Monotonic time (wall clock time)
+    - Performance counter time (CPU time)
+    - Custom timing messages
+
+    Example:
+        >>> # Global filtered params
+        >>> timing = TimingLogger(filtered_params=['password', 'secret'])
+        >>>
+        >>> # Additional per-function filtered params
+        >>> @timing.timeit(filtered_params=['extra_sensitive'])
+        >>> def my_function(arg1, password, extra_sensitive):
+        >>>     # Function code here
+        >>>     pass
+    """
+
+    def __init__(self, filtered_params: Optional[list[str]] = None):
+        """Initialize TimingLogger with optional filtered parameters.
+
+        Arguments:
+            filtered_params (Optional[list[str]], optional): List of parameter names to be redacted in logs
+        """
+        self.filtered_params = filtered_params or []
+
+    def _sanitize_value(
+        self,
+        key: str,
+        value: Any,
+        additional_filtered_params: Optional[list[str]] = None,
+    ) -> str:
+        """Sanitize values based on filtered parameters.
+
+        Arguments:
+            key (str): Parameter name
+            value (Any): Parameter value
+            additional_filtered_params (Optional[list[str]], optional): Additional parameters to filter
+
+        Returns:
+            str: Original value as string or "redacted" if parameter should be filtered
+        """
+        all_filtered_params = set(self.filtered_params)
+        if additional_filtered_params:
+            all_filtered_params.update(additional_filtered_params)
+
+        if key in all_filtered_params:
+            return "redacted"
+
+        # Handle different types of values
+        if isinstance(value, (str, int, float, bool)):
+            return str(value)
+        elif value is None:
+            return "None"
+        else:
+            # For objects, return their class name instead of the full repr
+            return f"<{value.__class__.__name__}>"
+
+    def _log_timing(
+        self,
+        func_name: str,
+        args: tuple,
+        kwargs: dict,
+        duration: float,
+        cpu_time: float,
+        filtered_params: Optional[list[str]] = None,
+        message: Optional[str] = None,
+    ) -> None:
+        """Internal method to log timing information.
+
+        Arguments:
+            func_name (str): Name of the function being timed
+            args (tuple): Positional arguments passed to the function
+            kwargs (dict): Keyword arguments passed to the function
+            duration (float): Wall clock duration in milliseconds
+            cpu_time (float): CPU time duration in milliseconds
+            filtered_params (Optional[list[str]], optional): Additional parameters to filter
+            message (Optional[str]): Optional custom message to include in log
+        """
+        timing_data = {
+            "type": "timing_info",
+            "function": func_name,
+            "args": [
+                self._sanitize_value(f"arg_{i}", arg, filtered_params)
+                for i, arg in enumerate(args)
+            ],
+            "kwargs": {
+                k: self._sanitize_value(k, v, filtered_params)
+                for k, v in kwargs.items()
+            },
+            "timing": {
+                "duration_ms": round(duration, 4),
+                "duration_sec": round(duration / 1000, 4),
+                "cpu_time_ms": round(cpu_time, 4),
+                "cpu_time_sec": round(cpu_time / 1000, 4),
+            },
+        }
+
+        if message:
+            timing_data["message"] = message
+
+        logger.debug(json.dumps(timing_data))
+
+    def timeit(
+        self,
+        func: Optional[Callable] = None,
+        *,
+        filtered_params: Optional[list[str]] = None,
+    ) -> Callable:
+        """Decorator to time function execution.
+
+        Note:
+            Can be used with or without parameters:
+            @timing.timeit
+            def func1(): ...
+
+            @timing.timeit(filtered_params=['sensitive'])
+            def func2(): ...
+
+        Arguments:
+            func (Optional[Callable]): The function to be timed
+            filtered_params (Optional[list[str]], optional): Additional parameters to filter for this specific function
+
+        Returns:
+            Callable: The wrapped function
+        """
+
+        def decorator(func: Callable) -> Callable:
+            """Decorator internal function that receives the outer function"""
+
+            @wraps(func)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                """Wrapper function to handle the outer real function"""
+                time_start = time.monotonic_ns()
+                perf_start = time.perf_counter_ns()
+
+                try:
+                    result = func(*args, **kwargs)
+                    return result
+                finally:
+                    time_end = time.monotonic_ns()
+                    perf_end = time.perf_counter_ns()
+
+                    duration = (time_end - time_start) / 1e6  # Convert to milliseconds
+                    cpu_time = (perf_end - perf_start) / 1e6  # Convert to milliseconds
+
+                    self._log_timing(
+                        func_name=func.__name__,
+                        args=args,
+                        kwargs=kwargs,
+                        duration=duration,
+                        cpu_time=cpu_time,
+                        filtered_params=filtered_params,
+                    )
+
+            return wrapper
+
+        # Handle both @timeit and @timeit(filtered_params=[...]) cases
+        if func is None:
+            return decorator
+        return decorator(func)

--- a/data/development/config/command-line-assistant/config.toml
+++ b/data/development/config/command-line-assistant/config.toml
@@ -15,7 +15,7 @@ key_file = "data/development/certificate/fake-key.pem"
 verify_ssl = false
 
 [logging]
-level = "DEBUG"
+level = "INFO"
 
 [logging.audit]
 enabled = false

--- a/docs/source/utils/benchmark.rst
+++ b/docs/source/utils/benchmark.rst
@@ -1,0 +1,8 @@
+Benchmark
+=========
+
+.. automodule:: command_line_assistant.utils.benchmark
+   :members:
+   :undoc-members:
+   :private-members:
+   :no-index:

--- a/docs/source/utils/index.rst
+++ b/docs/source/utils/index.rst
@@ -4,6 +4,7 @@ Utils
 .. toctree::
    :maxdepth: 2
 
+   benchmark
    cli
    environment
    renderers

--- a/tests/utils/test_benchmark.py
+++ b/tests/utils/test_benchmark.py
@@ -1,0 +1,199 @@
+import json
+import time
+from unittest.mock import patch
+
+import pytest
+
+from command_line_assistant.utils.benchmark import TimingLogger
+
+
+@pytest.fixture
+def mock_logger():
+    with patch("command_line_assistant.utils.benchmark.logger") as mock:
+        yield mock
+
+
+@pytest.fixture
+def timing_logger():
+    return TimingLogger()
+
+
+@pytest.fixture
+def timing_logger_with_filters():
+    return TimingLogger(filtered_params=["password", "api_key"])
+
+
+def test_init_no_filters():
+    logger = TimingLogger()
+    assert logger.filtered_params == []
+
+
+def test_init_with_filters():
+    filtered_params = ["password", "secret"]
+    logger = TimingLogger(filtered_params=filtered_params)
+    assert logger.filtered_params == filtered_params
+
+
+class TestSanitizeValue:
+    def test_no_filtering(self, timing_logger):
+        result = timing_logger._sanitize_value("param", "value")
+        assert result == "value"
+
+    def test_global_filtering(self, timing_logger_with_filters):
+        result = timing_logger_with_filters._sanitize_value("password", "secret123")
+        assert result == "redacted"
+
+    def test_additional_filtering(self, timing_logger):
+        result = timing_logger._sanitize_value(
+            "token", "abc123", additional_filtered_params=["token"]
+        )
+        assert result == "redacted"
+
+    def test_combined_filtering(self, timing_logger_with_filters):
+        result = timing_logger_with_filters._sanitize_value(
+            "token", "abc123", additional_filtered_params=["token"]
+        )
+        assert result == "redacted"
+
+        result = timing_logger_with_filters._sanitize_value("password", "secret123")
+        assert result == "redacted"
+
+
+class TestLogTiming:
+    def test_basic_logging(self, timing_logger, mock_logger):
+        timing_logger._log_timing(
+            func_name="test_func",
+            args=("arg1", "arg2"),
+            kwargs={"kwarg1": "value1"},
+            duration=100.0,
+            cpu_time=90.0,
+        )
+
+        mock_logger.debug.assert_called_once()
+        logged_data = json.loads(mock_logger.debug.call_args[0][0])
+
+        assert logged_data["function"] == "test_func"
+        assert logged_data["args"] == ["arg1", "arg2"]
+        assert logged_data["kwargs"] == {"kwarg1": "value1"}
+        assert "duration_ms" in logged_data["timing"]
+        assert "duration_sec" in logged_data["timing"]
+        assert "cpu_time_ms" in logged_data["timing"]
+        assert "cpu_time_sec" in logged_data["timing"]
+
+    def test_logging_with_filtering(self, timing_logger_with_filters, mock_logger):
+        timing_logger_with_filters._log_timing(
+            func_name="login",
+            args=(
+                "username",
+                "mysecretpass123",
+            ),  # Changed to make password position more explicit
+            kwargs={"api_key": "secretkey123", "normal_param": "visible"},
+            duration=100.0,
+            cpu_time=90.0,
+            filtered_params=["extra_param"],  # Additional filtered param
+        )
+
+        mock_logger.debug.assert_called_once()
+        logged_data = json.loads(mock_logger.debug.call_args[0][0])
+
+        # Test that args are properly sanitized
+        assert logged_data["args"] == [
+            "username",
+            str("mysecretpass123"),
+        ]  # Second arg isn't filtered since position doesn't indicate it's a password
+
+        # Test that kwargs are properly filtered
+        assert (
+            logged_data["kwargs"]["api_key"] == "redacted"
+        )  # Should be filtered due to global filter
+        assert (
+            logged_data["kwargs"]["normal_param"] == "visible"
+        )  # Should not be filtered
+
+        # Test timing data is present and correct
+        assert logged_data["timing"]["duration_ms"] == 100.0
+        assert logged_data["timing"]["cpu_time_ms"] == 90.0
+
+
+class TestTimeitDecorator:
+    def test_basic_timing(self, timing_logger, mock_logger):
+        @timing_logger.timeit
+        def simple_function():
+            time.sleep(0.1)
+            return "done"
+
+        result = simple_function()
+
+        assert result == "done"
+        mock_logger.debug.assert_called_once()
+        logged_data = json.loads(mock_logger.debug.call_args[0][0])
+
+        assert logged_data["function"] == "simple_function"
+        assert logged_data["timing"]["duration_ms"] >= 100  # At least 100ms
+        assert logged_data["timing"]["duration_sec"] >= 0.1  # At least 0.1s
+
+    def test_timing_with_args(self, timing_logger_with_filters, mock_logger):
+        @timing_logger_with_filters.timeit(filtered_params=["sensitive"])
+        def function_with_args(normal_arg, password, sensitive):
+            return "done"
+
+        result = function_with_args("visible", "secret123", "hidden")
+
+        assert result == "done"
+        mock_logger.debug.assert_called_once()
+        logged_data = json.loads(mock_logger.debug.call_args[0][0])
+
+        # Check args are properly logged - note that positional args are labeled as arg_0, arg_1, etc.
+        assert logged_data["args"][0] == "visible"  # arg_0 is not filtered
+        assert logged_data["args"][1] == str(
+            "secret123"
+        )  # arg_1 is not filtered by position alone
+        assert logged_data["args"][2] == str(
+            "hidden"
+        )  # arg_2 is not filtered by position alone
+
+        # Verify timing data exists
+        assert "timing" in logged_data
+        assert all(
+            key in logged_data["timing"]
+            for key in ["duration_ms", "duration_sec", "cpu_time_ms", "cpu_time_sec"]
+        )
+
+    def test_timing_with_exception(self, timing_logger, mock_logger):
+        @timing_logger.timeit
+        def failing_function():
+            raise ValueError("Test error")
+
+        with pytest.raises(ValueError):
+            failing_function()
+
+        # Should still log timing even if function fails
+        mock_logger.debug.assert_called_once()
+        logged_data = json.loads(mock_logger.debug.call_args[0][0])
+        assert logged_data["function"] == "failing_function"
+
+    def test_decorator_without_parameters(self, timing_logger, mock_logger):
+        @timing_logger.timeit
+        def simple_function():
+            return "done"
+
+        result = simple_function()
+        assert result == "done"
+        mock_logger.debug.assert_called_once()
+
+    def test_decorator_with_parameters(self, timing_logger, mock_logger):
+        @timing_logger.timeit(filtered_params=["sensitive"])
+        def function_with_sensitive(normal_param="visible", sensitive="hidden"):
+            return "done"
+
+        result = function_with_sensitive(
+            sensitive="secret_value", normal_param="normal_value"
+        )
+        assert result == "done"
+
+        logged_data = json.dumps(mock_logger.debug.call_args[0][0])
+        # Since we're passing these as kwargs, they will be properly filtered
+        assert "normal_value" in logged_data  # normal_param should be visible
+        assert "sensitive" in logged_data  # key should be visible
+        assert "secret_value" not in logged_data  # sensitive value should be redacted
+        assert "redacted" in logged_data  # should see the redacted value


### PR DESCRIPTION
This is an optional decorator that will log debug messages with timing information about the functions. It will be used only when the log level is set to debug.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
