### PR TITLE
[RSPEED-657] Add ability to load credentials from systemd

### DIFF
--- a/command_line_assistant/commands/history.py
+++ b/command_line_assistant/commands/history.py
@@ -236,7 +236,7 @@ class AllHistoryOperation(BaseHistoryOperation):
             # Display the conversation
             self._show_history(history)
         except HistoryNotAvailableError as e:
-            logger.error("Failed to retrieve the all history entries: %s", str(e))
+            logger.debug("Failed to retrieve the all history entries: %s", str(e))
             raise HistoryCommandException(
                 "Something went wrong while retrieving all history entries"
             ) from e

--- a/command_line_assistant/config/schemas/database.py
+++ b/command_line_assistant/config/schemas/database.py
@@ -1,8 +1,17 @@
 """Schemas for the database config."""
 
 import dataclasses
+import os
 from pathlib import Path
 from typing import Optional, Union
+
+#: Name of the credential containing the username to be loaded
+SYSTEMD_USERNAME_ID: str = "database-username"
+#: Name of the credential containing the password to be loaded
+SYSTEMD_PASSWORD_ID: str = "database-password"
+
+#: Tuple containing the allowed databases types
+ALLOWED_DATABASES = ("sqlite", "mysql", "postgresql")
 
 
 @dataclasses.dataclass
@@ -18,14 +27,20 @@ class DatabaseSchema:
         Reference: https://stackoverflow.com/a/4448568
 
     Attributes:
-        connection (str): The connection string.
+        type (str): The database type to connect
+        host (Optional[str], optioanl): The host for the database
+        database (Optional[str], optioanl): The name for the database
+        port (Optional[int], optioanl): The port of the database
+        username (Optional[str], optioanl): The username to connect
+        password (Optional[str], optioanl): The password to connect
+        connection_string (Optional[Union[str, Path]], optioanl): Database path for sqlite
     """
 
     type: str = "sqlite"  # 'sqlite', 'mysql', 'postgresql', etc.
     host: Optional[str] = None  # noqa: F821
     database: Optional[str] = None
     port: Optional[int] = None  # Optional for SQLite as it doesn't require host or port
-    user: Optional[str] = None  # Optional for SQLite
+    username: Optional[str] = None  # Optional for SQLite
     password: Optional[str] = None  # Optional for SQLite
     connection_string: Optional[Union[str, Path]] = (
         None  # Some databases like SQLite can use a file path
@@ -34,22 +49,53 @@ class DatabaseSchema:
     def __post_init__(self):
         """Post initialization method to normalize values"""
         # If the database type is not a supported one, we can just skip it.
-        allowed_databases = ("mysql", "sqlite", "postgresql")
-        if self.type not in allowed_databases:
+        if self.type not in ALLOWED_DATABASES:
             raise ValueError(
-                f"The database type must be one of {', '.join(allowed_databases)}, not {self.type}"
+                f"The database type must be one of {', '.join(ALLOWED_DATABASES)}, not {self.type}"
             )
 
         if self.connection_string:
             self.connection_string = Path(self.connection_string).expanduser()
 
-        # Post-initialization to set default values for specific db types
-        if self.type == "sqlite" and not self.connection_string:
-            self.connection_string = f"sqlite://{self.database}"
-        elif self.type == "mysql" and not self.port:
-            self.port = 3306  # Default MySQL port
-        elif self.type == "postgresql" and not self.port:
-            self.port = 5432  # Default PostgreSQL port
+        # Special handle for MySQL and PostgreSQL credentials
+        if self.type in ALLOWED_DATABASES[1:]:
+            if not self.username:
+                self.username = self._read_credentials_from_systemd(SYSTEMD_USERNAME_ID)
+
+            if not self.password:
+                self.password = self._read_credentials_from_systemd(SYSTEMD_PASSWORD_ID)
+
+    def _read_credentials_from_systemd(self, identifier: str) -> str:
+        """Read the credentials from systemd folder.
+
+        Note:
+            This should only happen in case the username/password is not
+            defined in the config file. This is a more secure way for the user
+            to specify their credentials without relying on writing it
+            un-encrypted in a configuration file.
+
+        Arguments:
+            identifier (str): The identifier to be read from systemd
+            credentials directory.
+
+        Raises:
+            ValueError: In case the `CREDENTIALS_DIRECTORY` is not present or
+            the credential file is empty.
+        """
+        systemd_credentials_dir = os.getenv("CREDENTIALS_DIRECTORY", None)
+        if not systemd_credentials_dir:
+            raise ValueError(
+                "Either username or password is missing from config file or systemd-creds."
+            )
+
+        credentials_file = Path(systemd_credentials_dir, identifier)
+
+        try:
+            return credentials_file.read_text()
+        except FileNotFoundError as e:
+            raise ValueError(
+                f"The credential file at '{credentials_file}' does not exist."
+            ) from e
 
     def get_connection_url(self) -> str:
         """
@@ -63,8 +109,8 @@ class DatabaseSchema:
         """
         connection_urls = {
             "sqlite": f"sqlite:///{self.connection_string}",
-            "mysql": f"mysql://{self.user}:{self.password}@{self.host}:{self.port}/{self.database}",
-            "postgresql": f"postgresql://{self.user}:{self.password}@{self.host}:{self.port}/{self.database}",
+            "mysql": f"mysql://{self.username}:{self.password}@{self.host}:{self.port}/{self.database}",
+            "postgresql": f"postgresql://{self.username}:{self.password}@{self.host}:{self.port}/{self.database}",
         }
 
         return connection_urls[self.type]

--- a/command_line_assistant/daemon/database/manager.py
+++ b/command_line_assistant/daemon/database/manager.py
@@ -57,15 +57,13 @@ class DatabaseManager:
         """
         try:
             connection_url = self._config.database.get_connection_url()
-
             # SQLite-specific settings
             if self._config.database.type == "sqlite":
-                connect_args = {"check_same_thread": False}
                 return create_engine(
                     connection_url,
                     echo=echo,
                     poolclass=StaticPool,
-                    connect_args=connect_args,
+                    connect_args={"check_same_thread": False},
                 )
 
             # For other databases, use standard pooling

--- a/data/development/config/command-line-assistant/config.toml
+++ b/data/development/config/command-line-assistant/config.toml
@@ -1,6 +1,6 @@
 [database]
 type = "sqlite"
-connection_string = "/tmp/history.db"
+connection_string = "~/.local/state/command-line-assistant/history.db"
 
 [history]
 enabled = true

--- a/docs/source/man/clad.8.rst
+++ b/docs/source/man/clad.8.rst
@@ -46,6 +46,9 @@ Files
 */usr/lib/systemd/system/clad.service*
     Systemd service file for clad
 
+*/etc/systemd/system/clad.service.d/*
+    Systemd unit override for clad
+
 Reference
 ---------
 

--- a/packaging/command-line-assistant.spec
+++ b/packaging/command-line-assistant.spec
@@ -72,12 +72,13 @@ popd
 %py3_install_wheel %{python_package_src}-%{version}-py3-none-any.whl
 
 # Create needed directories in buildroot
-%{__install} -d %{buildroot}/%{_sbindir}
 %{__install} -d -m 0755 %{buildroot}/%{_sysconfdir}/xdg/%{name}
+%{__install} -d -m 0755 %{buildroot}/%{_sysconfdir}/systemd/system/clad.service.d
 %{__install} -d -m 0755 %{buildroot}/%{_sharedstatedir}/%{name}
+%{__install} -d %{buildroot}/%{_sbindir}
 %{__install} -d %{buildroot}/%{_mandir}/man1
 %{__install} -d %{buildroot}/%{_mandir}/man8
-%{__install} -d %{buildroot}%{_datadir}/selinux/packages/%{selinuxtype}
+%{__install} -d %{buildroot}/%{_datadir}/selinux/packages/%{selinuxtype}
 
 # Move the daemon to /usr/sbin instead of /usr/bin
 %{__install} -m 0755 %{buildroot}/%{_bindir}/%{daemon_binary_name} %{buildroot}/%{_sbindir}/%{daemon_binary_name}
@@ -152,6 +153,7 @@ fi
 # Needed directories
 %dir %attr(0755, root, root) %{_sharedstatedir}/%{name}
 %dir %attr(0755, root, root) %{_sysconfdir}/xdg/%{name}
+%dir %attr(0755, root, root) %{_sysconfdir}/systemd/system/clad.service.d
 
 # Config file
 %attr(0600, root, root) %config(noreplace) %{_sysconfdir}/xdg/%{name}/config.toml


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
This patch introduces a mechanism for loading the database credentials
from systemd credentials. This allow the user to specify their
database username/password via systemd-creds, and the daemon will load
and use it.

It will only work if the username/password is empty in the config file.
If it is detected, we will use what is in the config.
<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-657](https://issues.redhat.ocm/browse/RSPEED-657)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
