### PR TITLE
[RSPEED-704] Show legal message on every shell session

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -30,7 +30,7 @@ from command_line_assistant.dbus.structures.chat import (
 from command_line_assistant.exceptions import ChatCommandException, StopInteractiveMode
 from command_line_assistant.rendering.decorators.colors import ColorDecorator
 from command_line_assistant.rendering.decorators.text import (
-    WriteOnceDecorator,
+    WriteOncePerSessionDecorator,
 )
 from command_line_assistant.rendering.renders.interactive import InteractiveRenderer
 from command_line_assistant.rendering.renders.spinner import SpinnerRenderer
@@ -275,7 +275,7 @@ class BaseChatOperation(BaseOperation):
         self.legal_renderer: TextRenderer = create_text_renderer(
             decorators=[
                 ColorDecorator(foreground="lightyellow"),
-                WriteOnceDecorator(state_filename="legal"),
+                WriteOncePerSessionDecorator(state_filename="legal"),
             ]
         )
         self.notice_renderer: TextRenderer = create_text_renderer(

--- a/command_line_assistant/rendering/decorators/text.py
+++ b/command_line_assistant/rendering/decorators/text.py
@@ -1,8 +1,10 @@
 """Module to track all *text* decorations applied to renderers"""
 
 import logging
+import os
 import shutil
 import textwrap
+from pathlib import Path
 from typing import Optional, Union
 
 from command_line_assistant.rendering.base import BaseDecorator
@@ -114,16 +116,17 @@ class TextWrapDecorator(BaseDecorator):
         )
 
 
-class WriteOnceDecorator(BaseDecorator):
+class WriteOncePerSessionDecorator(BaseDecorator):
     """Decorator that ensures content is written only once by checking a state file.
 
-    The state file is created under $XDG_STATE_HOME/command-line-assistant/<state_filename>
+    The state file is created under
+    $XDG_STATE_HOME/command-line-assistant/<state_filename>
 
     Example:
         This is an example on how to use this decorator:
 
         >>> message = "Message that will be printed only once"
-        >>> decorator = WriteOnceDecorator(state_filename="legal")
+        >>> decorator = WriteOncePerSessionDecorator(state_filename="legal")
         >>> renderer.update(decorator)
         >>> renderer.render(message)
         >>> renderer.render(message) # This won't show again
@@ -135,8 +138,9 @@ class WriteOnceDecorator(BaseDecorator):
         Arguments:
             state_filename (str): Name of the state file to create/check. Defaults to "written"
         """
-        self._state_dir = get_xdg_state_path()
-        self._state_file = self._state_dir / state_filename
+        self._state_dir: Path = get_xdg_state_path()
+        self._state_file: Path = self._state_dir / state_filename
+        self._parent_pid: str = str(os.getppid())
 
     def _should_write(self) -> bool:
         """Check if content should be written by verifying state file existence.
@@ -145,13 +149,14 @@ class WriteOnceDecorator(BaseDecorator):
             bool: In Return a boolean value if the state file can be written.
         """
         if self._state_file.exists():
-            logger.info(
-                "The state file already exists. Skipping writting it a second time."
-            )
-            return False
+            if self._state_file.read_text() == self._parent_pid:
+                logger.info(
+                    "The state file already exists. Skipping writting it a second time."
+                )
+                return False
         create_folder(self._state_dir)
         # Write state file
-        write_file("1", self._state_file)
+        write_file(self._parent_pid, self._state_file)
         return True
 
     def decorate(self, text: str) -> str:

--- a/tests/rendering/decorators/test_text.py
+++ b/tests/rendering/decorators/test_text.py
@@ -1,12 +1,13 @@
 import shutil
 from typing import Iterator
+from unittest import mock
 
 import pytest
 
 from command_line_assistant.rendering.decorators.text import (
     EmojiDecorator,
     TextWrapDecorator,
-    WriteOnceDecorator,
+    WriteOncePerSessionDecorator,
 )
 
 
@@ -131,7 +132,7 @@ class TestTextWrapDecorator:
         assert "    " not in result  # Should not contain multiple consecutive spaces
 
 
-class TestWriteOnceDecorator:
+class TestWriteOncePerSessionDecorator:
     @pytest.fixture
     def temp_state_dir(self, tmp_path):
         """Fixture to provide a temporary state directory"""
@@ -146,7 +147,7 @@ class TestWriteOnceDecorator:
             "command_line_assistant.rendering.decorators.text.get_xdg_state_path",
             lambda: temp_state_dir,
         )
-        return WriteOnceDecorator("test_state")
+        return WriteOncePerSessionDecorator("test_state")
 
     def test_first_write(self, decorator):
         """Test first write with decorator"""
@@ -169,8 +170,8 @@ class TestWriteOnceDecorator:
             lambda: temp_state_dir,
         )
 
-        decorator1 = WriteOnceDecorator("state1")
-        decorator2 = WriteOnceDecorator("state2")
+        decorator1 = WriteOncePerSessionDecorator("state1")
+        decorator2 = WriteOncePerSessionDecorator("state2")
 
         result1 = decorator1.decorate("Text 1")
         result2 = decorator2.decorate("Text 2")
@@ -187,7 +188,7 @@ class TestWriteOnceDecorator:
             lambda: non_existent_dir,
         )
 
-        decorator = WriteOnceDecorator("test_state")
+        decorator = WriteOncePerSessionDecorator("test_state")
         decorator.decorate("Test text")
 
         assert non_existent_dir.exists()
@@ -206,8 +207,8 @@ class TestWriteOnceDecorator:
             lambda: temp_state_dir,
         )
 
-        decorator1 = WriteOnceDecorator("same_state")
-        decorator2 = WriteOnceDecorator("same_state")
+        decorator1 = WriteOncePerSessionDecorator("same_state")
+        decorator2 = WriteOncePerSessionDecorator("same_state")
 
         result1 = decorator1.decorate("First text")
         result2 = decorator2.decorate("Second text")
@@ -239,8 +240,26 @@ class TestWriteOnceDecorator:
             lambda: temp_state_dir,
         )
 
-        decorator = WriteOnceDecorator(filename)
+        decorator = WriteOncePerSessionDecorator(filename)
         result = decorator.decorate("Test text")
 
         assert result == "Test text"
+        assert decorator._state_file.exists()
+
+    def test_different_pid(self, temp_state_dir, monkeypatch):
+        monkeypatch.setattr(
+            "command_line_assistant.rendering.decorators.text.get_xdg_state_path",
+            lambda: temp_state_dir,
+        )
+        monkeypatch.setattr("os.getppid", mock.Mock(side_effect=[0, 0, 1]))
+
+        decorator = WriteOncePerSessionDecorator("test")
+        assert decorator.decorate("Test text") == "Test text"
+
+        decorator = WriteOncePerSessionDecorator("test")
+        assert not decorator.decorate("Test second")
+
+        decorator = WriteOncePerSessionDecorator("test")
+        assert decorator.decorate("Test third") == "Test third"
+
         assert decorator._state_file.exists()


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
In this patch, the WriteOnceDecorator got renamed to
WriteOncePerSessionDecorator, to indicate that it will be written once
per session, not only once.

We also introduced the parent pid as a content of the file that get
written. This will help to identify that we are part of a session.
<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-704](https://issues.redhat.com/browse/RSPEED-704)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
