### PR TITLE
[RSPEED-632] Add message when history is not enabled

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -15,6 +15,7 @@ from command_line_assistant.commands.base import (
 )
 from command_line_assistant.dbus.exceptions import (
     ChatNotFoundError,
+    HistoryNotEnabledError,
 )
 from command_line_assistant.dbus.interfaces.chat import ChatInterface
 from command_line_assistant.dbus.interfaces.history import HistoryInterface
@@ -358,7 +359,13 @@ class BaseChatOperation(BaseOperation):
                     last_output=last_output,
                 )
 
-        self.history_proxy.WriteHistory(chat_id, user_id, final_question, response)
+        try:
+            self.history_proxy.WriteHistory(chat_id, user_id, final_question, response)
+        except HistoryNotEnabledError:
+            logger.warning(
+                "The history is disabled in the configuration file. Skipping the write to the history."
+            )
+
         return response
 
     @timing.timeit

--- a/command_line_assistant/commands/history.py
+++ b/command_line_assistant/commands/history.py
@@ -11,7 +11,10 @@ from command_line_assistant.commands.base import (
     CommandOperationFactory,
     CommandOperationType,
 )
-from command_line_assistant.dbus.exceptions import HistoryNotAvailableError
+from command_line_assistant.dbus.exceptions import (
+    HistoryNotAvailableError,
+    HistoryNotEnabledError,
+)
 from command_line_assistant.dbus.interfaces.chat import ChatInterface
 from command_line_assistant.dbus.interfaces.history import HistoryInterface
 from command_line_assistant.dbus.interfaces.user import UserInterface
@@ -32,9 +35,13 @@ from command_line_assistant.utils.renderers import (
 logger = logging.getLogger(__name__)
 
 
+#: Message for when the history is not available yet.
 HISTORY_NOT_AVAILABLE_MESSAGE = (
     "Looks like no history was found. Try asking something first!"
 )
+
+#: Message for when the history is not enabled yet.
+HISTORY_NOT_ENABLED_MESSAGE = "Looks like history is not enabled yet. Enable it in the configuration file before trying to access history."
 
 
 class HistoryOperationType(CommandOperationType):
@@ -151,6 +158,9 @@ class ClearHistoryOperation(BaseHistoryOperation):
         except HistoryNotAvailableError as e:
             logger.debug("Failed to clear the history: %s", str(e))
             raise HistoryCommandException(HISTORY_NOT_AVAILABLE_MESSAGE) from e
+        except HistoryNotEnabledError as e:
+            logger.debug("History is not enabled. Nothing to do.")
+            raise HistoryCommandException(HISTORY_NOT_ENABLED_MESSAGE) from e
 
 
 @HistoryOperationFactory.register(HistoryOperationType.FIRST)
@@ -170,6 +180,9 @@ class FirstHistoryOperation(BaseHistoryOperation):
         except HistoryNotAvailableError as e:
             logger.debug("Failed to retrieve the first history entry: %s", str(e))
             raise HistoryCommandException(HISTORY_NOT_AVAILABLE_MESSAGE) from e
+        except HistoryNotEnabledError as e:
+            logger.debug("History is not enabled. Nothing to do.")
+            raise HistoryCommandException(HISTORY_NOT_ENABLED_MESSAGE) from e
 
 
 @HistoryOperationFactory.register(HistoryOperationType.LAST)
@@ -189,6 +202,9 @@ class LastHistoryOperation(BaseHistoryOperation):
         except HistoryNotAvailableError as e:
             logger.debug("Failed to retrieve the last history entry: %s", str(e))
             raise HistoryCommandException(HISTORY_NOT_AVAILABLE_MESSAGE) from e
+        except HistoryNotEnabledError as e:
+            logger.debug("History is not enabled. Nothing to do.")
+            raise HistoryCommandException(HISTORY_NOT_ENABLED_MESSAGE) from e
 
 
 @HistoryOperationFactory.register(HistoryOperationType.FILTER)
@@ -216,6 +232,9 @@ class FilteredHistoryOperation(BaseHistoryOperation):
                 str(e),
             )
             raise HistoryCommandException(HISTORY_NOT_AVAILABLE_MESSAGE) from e
+        except HistoryNotEnabledError as e:
+            logger.debug("History is not enabled. Nothing to do.")
+            raise HistoryCommandException(HISTORY_NOT_ENABLED_MESSAGE) from e
 
 
 @HistoryOperationFactory.register(HistoryOperationType.ALL)
@@ -235,6 +254,9 @@ class AllHistoryOperation(BaseHistoryOperation):
         except HistoryNotAvailableError as e:
             logger.debug("Failed to retrieve the all history entries: %s", str(e))
             raise HistoryCommandException(HISTORY_NOT_AVAILABLE_MESSAGE) from e
+        except HistoryNotEnabledError as e:
+            logger.debug("History is not enabled. Nothing to do.")
+            raise HistoryCommandException(HISTORY_NOT_ENABLED_MESSAGE) from e
 
 
 class HistoryCommand(BaseCLICommand):

--- a/command_line_assistant/dbus/exceptions.py
+++ b/command_line_assistant/dbus/exceptions.py
@@ -32,6 +32,11 @@ class HistoryNotAvailableError(DBusError):
     """History for that particular user is not available."""
 
 
+@dbus_error("HistoryNotEnabledError", namespace=HISTORY_NAMESPACE)
+class HistoryNotEnabledError(DBusError):
+    """History for that particular user is not enabled."""
+
+
 @dbus_error("ChatNotFound", namespace=CHAT_NAMESAPCE)
 class ChatNotFoundError(DBusError):
     """Couldn't find chat for the given user."""

--- a/command_line_assistant/history/base.py
+++ b/command_line_assistant/history/base.py
@@ -49,14 +49,3 @@ class BaseHistoryPlugin(ABC):
         Arguments:
             user_id (str): The user's identifier
         """
-
-    def _check_if_history_is_enabled(self) -> bool:
-        """Check if the history is enabled in the configuration file.
-
-        Returns:
-            bool: If the history is enable or not.
-        """
-        if not self._config.history.enabled:
-            logger.info("History disabled. Nothing to do.")
-
-        return self._config.history.enabled

--- a/command_line_assistant/history/plugins/local.py
+++ b/command_line_assistant/history/plugins/local.py
@@ -64,9 +64,6 @@ class LocalHistory(BaseHistoryPlugin):
             CorruptedHistoryError: Raised when there's an error reading from the database.
             MissingHistoryFileError: Raised when the database file is missing.
         """
-        if not self._check_if_history_is_enabled():
-            return []
-
         try:
             return self._history_repository.select_all_history(user_id)
         except Exception as e:
@@ -86,9 +83,6 @@ class LocalHistory(BaseHistoryPlugin):
             CorruptedHistoryError: Raised when there's an error writing to the database.
             MissingHistoryFileError: Raised when the database file is missing.
         """
-        if not self._check_if_history_is_enabled():
-            return
-
         try:
             # Verify if the given chat_id has a history associated with it
             result = self._history_repository.select_by_chat_id(chat_id)

--- a/command_line_assistant/initialize.py
+++ b/command_line_assistant/initialize.py
@@ -65,9 +65,9 @@ def initialize() -> int:
         error_renderer.render(str(e))
         return 1
     except DBusError as e:
-        logger.error("Got exception from dbus: %s", str(e))
+        logger.debug("Got exception from dbus: %s", e)
         error_renderer.render(
-            f"Failed to communicate with daemon through dbus. Reason: {str(e)}"
+            f"Failed to communicate with CLAD through dbus. Reason: {str(e)}. Check the daemon logs with systemctl status clad"
         )
         return 1
     except KeyboardInterrupt as e:

--- a/tests/history/plugins/test_local.py
+++ b/tests/history/plugins/test_local.py
@@ -51,13 +51,6 @@ class TestLocalHistoryInitialization:
 class TestLocalHistoryRead:
     """Test cases for reading history."""
 
-    def test_read_disabled_history(
-        self, local_history: LocalHistory, mock_config: Mock
-    ):
-        """Should return empty list when history is disabled."""
-        mock_config.history.enabled = False
-        assert local_history.read("6d4e6b1e-dfcb-11ef-9b4f-52b437312584") == []
-
     def test_read_success(self, local_history: LocalHistory):
         """Should successfully read and format history entries."""
         # Create mock history entries
@@ -82,19 +75,6 @@ class TestLocalHistoryRead:
 
 class TestLocalHistoryWrite:
     """Test cases for writing history."""
-
-    def test_write_disabled_history(
-        self, local_history: LocalHistory, mock_config: Mock
-    ):
-        """Should not write when history is disabled."""
-        mock_config.history.enabled = False
-        local_history.write(
-            "6d4e6b1e-dfcb-11ef-9b4f-52b437312584",
-            "6d4e6b1e-dfcb-11ef-9b4f-52b437312584",
-            "query",
-            "response",
-        )
-        assert not local_history.read("6d4e6b1e-dfcb-11ef-9b4f-52b437312584")
 
     @pytest.mark.parametrize(
         "query,response",

--- a/tests/history/test_manager.py
+++ b/tests/history/test_manager.py
@@ -1,5 +1,6 @@
 import pytest
 
+from command_line_assistant.dbus.exceptions import HistoryNotEnabledError
 from command_line_assistant.history.base import BaseHistoryPlugin
 from command_line_assistant.history.manager import HistoryManager
 from command_line_assistant.history.plugins.local import LocalHistory
@@ -135,3 +136,29 @@ def test_history_manager_multiple_writes(history_manager):
     # 1 history, with multiple interactions
     assert len(history) == 1
     assert len(history[0].interactions) == len(entries)
+
+
+def test_read_disabled_history(mock_config):
+    """Raise exception when the history is not enabled"""
+    mock_config.history.enabled = False
+    manager = HistoryManager(mock_config, plugin=LocalHistory)
+    with pytest.raises(HistoryNotEnabledError, match="History is not enabled"):
+        manager.read("6d4e6b1e-dfcb-11ef-9b4f-52b437312584")
+
+
+def test_write_disabled_history(mock_config):
+    """Raise exception when the history is not enabled"""
+    mock_config.history.enabled = False
+    manager = HistoryManager(mock_config, plugin=LocalHistory)
+    uid = "6d4e6b1e-dfcb-11ef-9b4f-52b437312584"
+    with pytest.raises(HistoryNotEnabledError, match="History is not enabled"):
+        manager.write(uid, uid, "test", "test")
+
+
+def test_clear_disabled_history(mock_config):
+    """Raise exception when the history is not enabled"""
+    mock_config.history.enabled = False
+    manager = HistoryManager(mock_config, plugin=LocalHistory)
+    uid = "6d4e6b1e-dfcb-11ef-9b4f-52b437312584"
+    with pytest.raises(HistoryNotEnabledError, match="History is not enabled"):
+        manager.clear(uid)

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -2,6 +2,7 @@ from argparse import Namespace
 from unittest.mock import Mock, patch
 
 import pytest
+from dasbus.error import DBusError
 
 from command_line_assistant.commands.base import BaseCLICommand
 from command_line_assistant.constants import VERSION
@@ -167,3 +168,12 @@ def test_initialize_command_selection(argv, expected_command):
 
         assert result == 1
         mock_command.assert_called_once()
+
+
+def test_dbus_initialization_error(capsys):
+    with patch("command_line_assistant.initialize.read_stdin") as mock_stdin:
+        mock_stdin.side_effect = DBusError("Name is not active")
+        initialize()
+
+    captured = capsys.readouterr()
+    assert "Failed to communicate with CLAD through dbus." in captured.err


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
This patch introduces a small handler to show a message to the user in
case the history is not enabled during the history calls.

Before this patch, a badly formatted error message would be used
instead, which is not helpful.
<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-632](https://issues.redhat.com/browse/RSPEED-632)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
