### PR TITLE
Add KeyboardInterrupt exception catch to top-level call

### DIFF
--- a/command_line_assistant/initialize.py
+++ b/command_line_assistant/initialize.py
@@ -70,3 +70,7 @@ def initialize() -> int:
             f"Failed to communicate with daemon through dbus. Reason: {str(e)}"
         )
         return 1
+    except KeyboardInterrupt as e:
+        logger.debug("Got exception from keyboard handling: %s", str(e))
+        error_renderer.render("Uh, oh! Keyboard interrupt detected.")
+        return 1

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -127,6 +127,15 @@ def test_initialize_bad_stdin(capsys):
     assert "\x1b[31m🙁 Binary input are not supported.\x1b[0m\n" in captured.err
 
 
+def test_initialize_keyboard_interrupt(capsys):
+    with patch("command_line_assistant.initialize.read_stdin") as mock_stdin:
+        mock_stdin.side_effect = KeyboardInterrupt("Interrupted")
+        initialize()
+
+    captured = capsys.readouterr()
+    assert "\x1b[31m🙁 Uh, oh! Keyboard interrupt detected.\x1b[0m\n" in captured.err
+
+
 @pytest.mark.parametrize(
     (
         "argv",


### PR DESCRIPTION
Try to handle keyboardinterrupt in the top-level call (initialize) to prevent a traceback being shown to the user.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
