### PR TITLE
Fix search ordering in last output function

### DIFF
--- a/command_line_assistant/rendering/decorators/text.py
+++ b/command_line_assistant/rendering/decorators/text.py
@@ -154,7 +154,7 @@ class WriteOncePerSessionDecorator(BaseDecorator):
                     "The state file already exists. Skipping writting it a second time."
                 )
                 return False
-        create_folder(self._state_dir)
+        create_folder(self._state_dir, parents=True)
         # Write state file
         write_file(self._parent_pid, self._state_file)
         return True
@@ -163,7 +163,8 @@ class WriteOncePerSessionDecorator(BaseDecorator):
         """Write the text only if it hasn't been written before.
 
         Arguments:
-            text (str): The text that needs to be decorated. This usually is being set from a renderer class.
+            text (str): The text that needs to be decorated. This usually is
+            being set from a renderer class.
 
         Returns:
             str: The text decorated if it can writes, otherwise, blank string.

--- a/command_line_assistant/terminal/parser.py
+++ b/command_line_assistant/terminal/parser.py
@@ -23,6 +23,10 @@ def parse_terminal_output() -> list[dict[str, str]]:
     result = []
 
     if not OUTPUT_FILE_NAME.exists():
+        logger.warning(
+            "Terminal output requested but couldn't find file at %s. Returning empty list.",
+            OUTPUT_FILE_NAME,
+        )
         return result
 
     with OUTPUT_FILE_NAME.open(mode="r") as handler:
@@ -43,8 +47,6 @@ def parse_terminal_output() -> list[dict[str, str]]:
                 )
                 return result
 
-    # Reverse the list before returning
-    result.reverse()
     return result
 
 
@@ -58,9 +60,13 @@ def find_output_by_index(index: int, output: list) -> str:
     Returns:
         str: In case it finds the output, otherwise, empty string.
     """
-    logger.info("Checking for output with index %s", index)
     try:
-        return output[index]["output"]
+        logger.info("Checking for output with index %s", index)
+        found_output = output[index]["output"]
+        logger.debug(
+            "Found output with index %s, and contents: %s", index, found_output
+        )
+        return found_output
     except (IndexError, KeyError):
         logger.warning("Couldn't find a match for index %s", index)
         return ""

--- a/command_line_assistant/terminal/reader.py
+++ b/command_line_assistant/terminal/reader.py
@@ -103,7 +103,7 @@ def start_capturing() -> None:
     os.environ["TERM"] = os.environ.get("TERM", "xterm")
 
     # The create_folder function will silently fail in case the folder exists.
-    create_folder(OUTPUT_FILE_NAME.parent)
+    create_folder(OUTPUT_FILE_NAME.parent, parents=True)
 
     # Initialize the file
     write_file("", OUTPUT_FILE_NAME)

--- a/tests/terminal/test_parser.py
+++ b/tests/terminal/test_parser.py
@@ -66,4 +66,5 @@ def test_find_output_by_index(index, expected):
 
 
 def test_clean_parsed_text():
-    assert parser.clean_parsed_text("\u001b[?2004l\r\r\nexit") == "exit"
+    result = parser.clean_parsed_text("\u001b[?2004l\r\r\nexit")
+    assert result == "exit"

--- a/tests/utils/test_files.py
+++ b/tests/utils/test_files.py
@@ -38,11 +38,19 @@ def test_guess_mimetype_file_extension(file, mimetype, tmp_path):
 def test_create_folder(path, mode, expected, tmp_path):
     folder_path = tmp_path / path
     if mode:
-        create_folder(folder_path, mode)
+        create_folder(folder_path, mode=mode)
     else:
         create_folder(folder_path)
 
     assert oct(folder_path.stat().st_mode).endswith(expected)
+
+
+def test_create_folder_with_parents(tmp_path):
+    folder_path = tmp_path / "test/test"
+    create_folder(folder_path, parents=True)
+
+    assert folder_path.exists()
+    assert folder_path.parent.exists()
 
 
 def test_create_folder_already_exists(tmp_path, caplog):


### PR DESCRIPTION
Before, we were reverting the list and that was causing trouble while trying to read the last terminal output. Now, we are trying to convert the index to a negative number.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
