### PR TITLE
Use mock_config instead of Config object in tests

### DIFF
--- a/tests/dbus/test_server.py
+++ b/tests/dbus/test_server.py
@@ -1,6 +1,5 @@
 from unittest import mock
 
-from command_line_assistant.config import Config
 from command_line_assistant.dbus import server
 
 
@@ -27,16 +26,15 @@ def test_serve_registers_services(monkeypatch, mock_config):
     assert system_bus_mock.register_service.call_count == 3
 
 
-def test_serve_cleanup_on_exception(monkeypatch):
+def test_serve_cleanup_on_exception(monkeypatch, mock_config):
     event_loop_mock = mock.Mock()
     event_loop_mock.return_value.run.side_effect = Exception("Test error")
     system_bus_mock = mock.Mock()
     monkeypatch.setattr(server, "EventLoop", event_loop_mock)
     monkeypatch.setattr(server, "SYSTEM_BUS", system_bus_mock)
-    config = Config()
 
     try:
-        server.serve(config)
+        server.serve(mock_config)
     except Exception:
         pass
 


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
