### PR TITLE
Fix incorrect use of marker in terminal reader

### DIFF
--- a/command_line_assistant/commands/shell.py
+++ b/command_line_assistant/commands/shell.py
@@ -14,7 +14,6 @@ from command_line_assistant.commands.base import (
 )
 from command_line_assistant.exceptions import ShellCommandException
 from command_line_assistant.integrations import (
-    BASH_ESSENTIAL_EXPORTS,
     BASH_INTERACTIVE,
 )
 from command_line_assistant.rendering.renders.text import TextRenderer
@@ -72,7 +71,6 @@ class BaseShellOperation(BaseOperation):
         """Internal function to initialize the bash folder"""
         # Always ensure essential exports are in place
         create_folder(BASH_RC_D_PATH)
-        write_file(BASH_ESSENTIAL_EXPORTS, ESSENTIAL_EXPORTS_FILE)
 
     def _write_bash_functions(self, file: Path, contents: Union[bytes, str]) -> None:
         """Internal funtion to write the bash function to the desired location
@@ -147,6 +145,7 @@ class EnableTerminalCapture(BaseShellOperation):
         self.text_renderer.render(
             "Starting terminal reader. Press Ctrl + D to stop the capturing."
         )
+        self._initialize_bash_folder()
         start_capturing()
 
 

--- a/command_line_assistant/integrations.py
+++ b/command_line_assistant/integrations.py
@@ -36,10 +36,3 @@ __c_interactive() {
 # Bind Ctrl+J to the interactive function
 bind -x '"\C-j": __c_interactive'
 """
-
-#: Exports the $PROMPT_COMMAND variable to an internal variable managed by CLA.
-#: This will allow us to inject our marker to enable the caret feature.
-BASH_ESSENTIAL_EXPORTS: str = r"""
-export CLA_USER_SHELL_PS1=$PS1
-export CLA_USER_SHELL_PROMPT_COMMAND=$PROMPT_COMMAND
-"""

--- a/tests/commands/test_shell.py
+++ b/tests/commands/test_shell.py
@@ -14,7 +14,6 @@ from command_line_assistant.commands.shell import (
     register_subcommand,
 )
 from command_line_assistant.exceptions import ShellCommandException
-from command_line_assistant.integrations import BASH_ESSENTIAL_EXPORTS
 from command_line_assistant.utils.renderers import create_text_renderer
 
 
@@ -33,13 +32,9 @@ def mock_bash_rc(monkeypatch, tmp_path):
 
 
 def test_initialize_bash_folder(default_kwargs, tmp_path):
-    essential_exports_file = tmp_path / "cla-exports.bashrc"
     bash_rc_d = tmp_path / ".bashrc.d"
     BaseShellOperation(**default_kwargs)._initialize_bash_folder()
 
-    assert essential_exports_file.exists()
-    assert BASH_ESSENTIAL_EXPORTS == essential_exports_file.read_text()
-    assert oct(essential_exports_file.stat().st_mode).endswith("600")
     assert oct(bash_rc_d.stat().st_mode).endswith("700")
 
 

--- a/tests/terminal/test_reader.py
+++ b/tests/terminal/test_reader.py
@@ -75,7 +75,7 @@ def test_terminal_recorder_write_json_block(tmp_path, get_terminal_size_packed):
     ("data", "expected"),
     (
         (b"test", b"test"),
-        (b"test%c", b"test"),
+        (b"\x1b]test", b"\x1b]test"),
         (b"test\n\r", b"test\n\r"),
     ),
 )
@@ -92,7 +92,7 @@ def test_terminal_recorder_read(
 
 
 @pytest.mark.parametrize(
-    ("data", "expected"), ((b"test", b"test"), (b"test%c", b"test"))
+    ("data", "expected"), ((b"test", b"test"), (b"\x1b]test", b"\x1b]test"))
 )
 def test_terminal_recorder_read_in_command_false(
     data, expected, monkeypatch, tmp_path, get_terminal_size_packed


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
