### PR TITLE
Add cla binary and a symlink for c

### DIFF
--- a/packaging/command-line-assistant.spec
+++ b/packaging/command-line-assistant.spec
@@ -1,6 +1,7 @@
 # RPM Specific
 %define python_package_src command_line_assistant
 %define binary_name c
+%define symlink_binary_name cla
 %define daemon_binary_name clad
 
 %define selinux_policyver 41.27-1
@@ -84,6 +85,10 @@ popd
 %{__install} -m 0755 %{buildroot}/%{_bindir}/%{daemon_binary_name} %{buildroot}/%{_sbindir}/%{daemon_binary_name}
 %{__rm} %{buildroot}/%{_bindir}/%{daemon_binary_name}
 
+# Symlink `c` to `cla`
+ln -sr %{buildroot}/%{_bindir}/%{binary_name} %{buildroot}/%{_bindir}/%{symlink_binary_name}
+ln -sr %{buildroot}%{_mandir}/man1/%{binary_name}.1 %{buildroot}%{_mandir}/man1/%{symlink_binary_name}.1
+
 # System units
 %{__install} -D -m 0644 data/release/systemd/%{daemon_binary_name}.service %{buildroot}/%{_unitdir}/%{daemon_binary_name}.service
 
@@ -134,6 +139,7 @@ fi
 
 # Binaries
 %{_bindir}/%{binary_name}
+%{_bindir}/%{symlink_binary_name}
 %{_sbindir}/%{daemon_binary_name}
 
 # System units
@@ -147,6 +153,7 @@ fi
 
 # Manpages
 %{_mandir}/man1/%{binary_name}.1.gz
+%{_mandir}/man1/%{symlink_binary_name}.1.gz
 %{_mandir}/man8/%{daemon_binary_name}.8.gz
 
 


### PR DESCRIPTION
To give users another option to use our tooling, we are renaming the main binary to `cla` and giving a symlink to `c` to keep the usage the same.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
