### PR TITLE
Fix session ssl certs not being loaded properly

### DIFF
--- a/command_line_assistant/daemon/http/adapters.py
+++ b/command_line_assistant/daemon/http/adapters.py
@@ -1,41 +1,12 @@
 """Main module to track the adapters for the http backend."""
 
-import ssl
-from pathlib import Path
+import logging
 from typing import Union
 
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
-
-class SSLAdapter(HTTPAdapter):
-    """Create an adapter to use a custom SSL context in requests.
-
-    Attributes:
-        cert_file (Path): The path to the cert file on the system
-        key_file (Path): The path to the key file on the system
-        ssl_context: Any additional ssl context that needs to be used
-    """
-
-    def __init__(self, cert_file: Path, key_file: Path, ssl_context=None, **kwargs):
-        """Constructor of the class
-
-        Arguments:
-            cert_file (Path): The path to the cert file on the system
-            key_file (Path): The path to the key file on the system
-            ssl_context: Any additional ssl context that needs to be used. Defaults to None.
-        """
-        self.cert_file = cert_file
-        self.key_file = key_file
-        self.ssl_context = ssl_context or ssl.create_default_context()
-        super().__init__(**kwargs)
-
-    def init_poolmanager(self, *args, **kwargs) -> None:
-        """Initialize the poolmanager"""
-        # Load the certificate and key into the SSL context
-        self.ssl_context.load_cert_chain(certfile=self.cert_file, keyfile=self.key_file)
-        kwargs["ssl_context"] = self.ssl_context
-        super().init_poolmanager(*args, **kwargs)
+logger = logging.getLogger(__name__)
 
 
 class RetryAdapter(HTTPAdapter):
@@ -56,6 +27,7 @@ class RetryAdapter(HTTPAdapter):
             max_retries (Union[Retry, int, None], optional): The maximum number of retires. Defaults to 3.
             pool_block (bool, optional): If the pool should be blocked. Defaults to False.
         """
+        logger.info("Configuring retry adapter with max_retries of %s", max_retries)
         retries = Retry(
             total=max_retries,
             backoff_factor=0.1,

--- a/command_line_assistant/daemon/http/session.py
+++ b/command_line_assistant/daemon/http/session.py
@@ -1,15 +1,13 @@
 """Handle the http sessions that the daemon issues to the backend."""
 
 import logging
-from ssl import SSLError
 
 import urllib3
 from requests.sessions import Session
 
 from command_line_assistant.config import Config
 from command_line_assistant.constants import VERSION
-from command_line_assistant.daemon.http.adapters import RetryAdapter, SSLAdapter
-from command_line_assistant.dbus.exceptions import RequestFailedError
+from command_line_assistant.daemon.http.adapters import RetryAdapter
 
 #: Define the custom user agent for clad
 USER_AGENT = f"clad/{VERSION}"
@@ -51,21 +49,7 @@ def get_session(config: Config) -> Session:
         session.verify = False
         return session
 
-    try:
-        ssl_adapter = SSLAdapter(
-            cert_file=config.backend.auth.cert_file,  # type: ignore
-            key_file=config.backend.auth.key_file,  # type: ignore
-        )
-    except SSLError as e:
-        raise RequestFailedError(
-            "Failed to load certificate in cert chain. If needed, regenerate the certificate with subscription-manager and try again."
-        ) from e
-    except FileNotFoundError as e:
-        raise RequestFailedError(
-            f"Couldn't find certificate files at '{config.backend.auth.cert_file.parent}' folder."  # pyright: ignore[reportAttributeAccessIssue]
-        ) from e
-
-    # Mount the adapter for the given endpoint.
-    session.mount(config.backend.endpoint, ssl_adapter)
+    logger.info("Configuring SSLAdapter")
+    session.cert = (config.backend.auth.cert_file, config.backend.auth.key_file)  # type: ignore
 
     return session


### PR DESCRIPTION
We were using the SSLAdapters wrong this entire time. Now that we can test against staging, we saw that the certs were not being loaded correctly. This patch simplify this process to attach the certs to the session and let requests to handle it.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
