### PR TITLE
[RSPEED-773, RSPEED-774] Fix incorrect key on database schema

### DIFF
--- a/data/release/xdg/config.toml
+++ b/data/release/xdg/config.toml
@@ -13,7 +13,7 @@ connection_string = "/var/lib/command-line-assistant/history.db"
 # host = "localhost"
 # port = "5432"
 # database = "history"
-# user = "your-user"
+# username = "your-user"
 # password = "your-password"
 
 # Or, to use mysql, uncomment the following:
@@ -22,7 +22,7 @@ connection_string = "/var/lib/command-line-assistant/history.db"
 # host = "localhost"
 # port = "3306"
 # database = "history"
-# user = "your-user"
+# username = "your-user"
 # password = "your-password"
 
 # History management configuration


### PR DESCRIPTION
The database schema was referencing the `user` key instead of `username`

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-773](https://issues.redhat.com/browse/RSPEED-773)
- [RSPEED-774](https://issues.redhat.com/browse/RSPEED-774)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
