### PR TITLE
[RSPEED-780, RSPEED-782] Add a --from-chat switch to history to filter out conversation

### DIFF
--- a/command_line_assistant/daemon/database/models/history.py
+++ b/command_line_assistant/daemon/database/models/history.py
@@ -15,6 +15,7 @@ class HistoryModel(BaseModel):
     chat_id = Column(GUID(), ForeignKey("chat.id"), nullable=False)
 
     interactions = relationship("InteractionModel", lazy="subquery", backref="history")
+    chats = relationship("ChatModel", lazy="subquery", backref="history")
 
 
 class InteractionModel(BaseModel):

--- a/command_line_assistant/daemon/database/repository/base.py
+++ b/command_line_assistant/daemon/database/repository/base.py
@@ -190,3 +190,22 @@ class BaseRepository:
 
         with self._manager.session() as session:
             session.execute(statement=statement)
+
+    def delete_by_chat_id(self, chat_id: Union[UUID, str]) -> None:
+        """Default method to remove entries from the database.
+
+        Note:
+            This method will actually call `update` internally to update the
+            `deleted_at` field in the table.
+
+        Arguments:
+            chat_id (Union[UUID, str]): The unique identifier to query in the database.
+        """
+        statement = (
+            update(self._model)
+            .values({"deleted_at": datetime.now()})
+            .where(self._model.chat_id == chat_id)
+        )
+
+        with self._manager.session() as session:
+            session.execute(statement=statement)

--- a/command_line_assistant/dbus/structures/history.py
+++ b/command_line_assistant/dbus/structures/history.py
@@ -12,17 +12,23 @@ class HistoryEntry(BaseDataMixin, DBusData):
     """Represents a single history item with query and response"""
 
     def __init__(
-        self, question: Str = "", response: Str = "", created_at: Str = ""
+        self,
+        question: Str = "",
+        response: Str = "",
+        chat_name: Str = "",
+        created_at: Str = "",
     ) -> None:
         """Constructor of class.
 
         Arguments:
             question (Str): The user question
             response (Str): The llm response
+            chat_name (Str): The name of the chat associated with the question
             created_at (Str): When the record was created.
         """
         self._question: Str = question
         self._response: Str = response
+        self._chat_name: Str = chat_name
         self._created_at: Str = created_at
         super().__init__()
 
@@ -61,6 +67,24 @@ class HistoryEntry(BaseDataMixin, DBusData):
             value (Str): Value to be set to the internal property
         """
         self._response = value
+
+    @property
+    def chat_name(self) -> Str:
+        """Property for internal chat_name attribute.
+
+        Returns:
+            Str: The value of chat_name
+        """
+        return self._chat_name
+
+    @chat_name.setter
+    def chat_name(self, value: Str) -> None:
+        """Set a new chat_name
+
+        Arguments:
+            value (Str): Value to be set to the internal property
+        """
+        self._chat_name = value
 
     @property
     def created_at(self) -> Str:

--- a/command_line_assistant/history/base.py
+++ b/command_line_assistant/history/base.py
@@ -32,6 +32,18 @@ class BaseHistoryPlugin(ABC):
         """
 
     @abstractmethod
+    def read_from_chat(self, user_id: str, from_chat: str) -> HistoryModel:
+        """Abstract method to represent a read operation from a specific chat
+
+        Arguments:
+            user_id (str): The user's identifier
+            from_chat (str): The chat name
+
+        Returns:
+            HistoryModel: Should return an instance of HistoryModel.
+        """
+
+    @abstractmethod
     def write(self, chat_id: str, user_id: str, query: str, response: str) -> None:
         """Abstract method to represent a write operation
 
@@ -48,4 +60,13 @@ class BaseHistoryPlugin(ABC):
 
         Arguments:
             user_id (str): The user's identifier
+        """
+
+    @abstractmethod
+    def clear_from_chat(self, user_id: str, from_chat: str) -> None:
+        """Abstract method to represent a clear from chat operation
+
+        Arguments:
+            user_id (str): The user's identifier
+            from_chat (str): The chat name
         """

--- a/command_line_assistant/history/manager.py
+++ b/command_line_assistant/history/manager.py
@@ -100,6 +100,24 @@ class HistoryManager:
         self._check_if_history_is_enabled()
         return self._instance.read(user_id)
 
+    def read_from_chat(self, user_id: str, from_chat: str) -> list[HistoryModel]:
+        """Read history entries using the current plugin.
+
+        Arguments:
+            user_id (str): The user's identifier
+
+        Raises:
+            RuntimeError: If no plugin is set
+
+        Returns:
+            Union[list, Sequence[Any]]: List of history entries
+        """
+        if not self._instance:
+            raise RuntimeError(HISTORY_PLUGIN_ERROR_MESSAGE)
+
+        self._check_if_history_is_enabled()
+        return self._instance.read_from_chat(user_id, from_chat)
+
     def write(self, chat_id: str, user_id: str, query: str, response: str) -> None:
         """Write a new history entry using the current plugin.
 
@@ -132,3 +150,18 @@ class HistoryManager:
 
         self._check_if_history_is_enabled()
         self._instance.clear(user_id)
+
+    def clear_from_chat(self, user_id: str, from_chat: str) -> None:
+        """Clear all history entries.
+
+        Arguments:
+            user_id (str): The user's identifier
+
+        Raises:
+            RuntimeError: If no plugin is set
+        """
+        if not self._instance:
+            raise RuntimeError(HISTORY_PLUGIN_ERROR_MESSAGE)
+
+        self._check_if_history_is_enabled()
+        self._instance.clear_from_chat(user_id, from_chat)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,3 +121,8 @@ def mock_stream():
 @pytest.fixture
 def mock_context(mock_config):
     return DaemonContext(mock_config)
+
+
+@pytest.fixture
+def universal_user_id():
+    return "ca427c50-ff49-11ef-9209-52b437312584"

--- a/tests/dbus/structures/test_history.py
+++ b/tests/dbus/structures/test_history.py
@@ -11,16 +11,20 @@ def test_history_entry_init():
 
 
 @pytest.mark.parametrize(
-    ("question", "response", "created_at"),
+    ("question", "response", "chat_name", "created_at"),
     (
-        ("question", "response", ""),
-        ("", "response", "2025-01-31 09:10:22.991148"),
+        ("question", "response", "test", ""),
+        ("", "response", "test", "2025-01-31 09:10:22.991148"),
+        ("", "response", "", "2025-01-31 09:10:22.991148"),
+        ("", "", "", ""),
+        ("", "", "test", ""),
     ),
 )
-def test_history_entry_setter(question, response, created_at):
-    history = HistoryEntry(question, response, created_at)
+def test_history_entry_setter(question, response, chat_name, created_at):
+    history = HistoryEntry(question, response, chat_name, created_at)
     assert history.question == question
     assert history.response == response
+    assert history.chat_name == chat_name
     assert history.created_at == created_at
 
 

--- a/tests/history/test_manager.py
+++ b/tests/history/test_manager.py
@@ -1,5 +1,6 @@
 import pytest
 
+from command_line_assistant.daemon.database.models.history import HistoryModel
 from command_line_assistant.dbus.exceptions import HistoryNotEnabledError
 from command_line_assistant.history.base import BaseHistoryPlugin
 from command_line_assistant.history.manager import HistoryManager
@@ -10,18 +11,27 @@ class MockHistoryPlugin(BaseHistoryPlugin):
     def __init__(self, config):
         super().__init__(config)
         self.read_called = False
+        self.read_from_chat_called = True
         self.write_called = False
         self.clear_called = False
+        self.clear_from_chat_called = True
 
     def read(self, user_id):
         self.read_called = True
         return []
+
+    def read_from_chat(self, user_id, from_chat):
+        self.read_from_chat_called = True
+        return HistoryModel
 
     def write(self, chat_id, user_id, query: str, response: str) -> None:
         self.write_called = True
 
     def clear(self, user_id) -> None:
         self.clear_called = True
+
+    def clear_from_chat(self, user_id, from_chat):
+        self._clear_from_chat_called = True
 
 
 @pytest.fixture


### PR DESCRIPTION
We were missing a filter option to let users filter out by specific chats. This patch introduces the --from-chat cli switch to add that.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-780](https://issues.redhat.com/browse/RSPEED-780)
- [RSPEED-782](https://issues.redhat.com/browse/RSPEED-782)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
