### PR TITLE
[RSPEED-781] Add explanation for --description in chat command

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -673,7 +673,7 @@ def register_subcommand(parser: SubParsersAction) -> None:
     chat_arguments.add_argument(
         "--description",
         nargs="?",
-        help="Give a description to the chat session",
+        help="Give a description to the chat session. Parameter has to be used together with sending a query. Otherwise has no effect.",
         default="Default Command Line Assistant Chat.",
     )
 


### PR DESCRIPTION
To follow what we have done for the `--name`, we are adding a description in the help text to help users when using the --description switch.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-781](https://issues.redhat.com/browse/RSPEED-781)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
