### PR TITLE
Fix 'where' conditions for sqlalchemy

### DIFF
--- a/command_line_assistant/daemon/database/repository/base.py
+++ b/command_line_assistant/daemon/database/repository/base.py
@@ -47,9 +47,7 @@ class BaseRepository:
         Returns:
             Any: Information retrieved from the database
         """
-        statement = select(self._model).where(
-            self._model.deleted_at == None,  # noqa
-        )
+        statement = select(self._model).filter(self._model.deleted_at.is_(None))
 
         with self._manager.session() as session:
             return session.execute(statement=statement).scalars().all()
@@ -104,9 +102,7 @@ class BaseRepository:
         Returns:
             Any: The first information retrieved from the database
         """
-        statement = select(self._model).where(
-            self._model.deleted_at == None,  # noqa
-        )
+        statement = select(self._model).filter(self._model.deleted_at.is_(None))
 
         with self._manager.session() as session:
             return session.execute(statement=statement).first()
@@ -143,8 +139,9 @@ class BaseRepository:
         statement = (
             select(self._model)
             .where(
-                self._model.name == name and self._model.user_id == user_id,  # noqa
+                self._model.name == name,  # noqa
             )
+            .where(self._model.user_id == user_id)
             .filter(self._model.deleted_at.is_(None))
         )
 

--- a/command_line_assistant/dbus/interfaces/chat.py
+++ b/command_line_assistant/dbus/interfaces/chat.py
@@ -141,6 +141,7 @@ class ChatInterface(InterfaceTemplate):
         Returns:
             Str: The identifier of the chat session.
         """
+
         result = self._chat_repository.select_by_name(user_id, name)
 
         if not result:
@@ -171,7 +172,7 @@ class ChatInterface(InterfaceTemplate):
             {"user_id": user_id, "name": name, "description": description}
         )
         logger.info(
-            "New chat session created with for user.",
+            "New chat session created for user.",
             extra={"audit": True, "identifier": identifier, "chat_name": name},
         )
         return str(identifier[0])


### PR DESCRIPTION
We had a bug where the condition was always returning True and causing users to share history

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
