### PR TITLE
[RSPEED-654] Prevent one character input from query_string and stdin

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -589,6 +589,16 @@ class ChatCommand(BaseCLICommand):
         error_renderer = create_error_renderer()
         operation_factory = ChatOperationFactory()
         try:
+            if (self._args.query_string and len(self._args.query_string) <= 1) or (
+                self._args.stdin and len(self._args.stdin) <= 1
+            ):
+                logger.debug(
+                    "Either query or stdin had length 1. We require that they have at least 2 or more characters."
+                )
+                raise ChatCommandException(
+                    "You query needs to have two or more characters."
+                )
+
             operation = operation_factory.create_operation(
                 self._args,
                 self._context,
@@ -620,7 +630,10 @@ def register_subcommand(parser: SubParsersAction) -> None:
     question_group = chat_parser.add_argument_group("Question Options")
     # Positional argument, required only if no optional arguments are provided
     question_group.add_argument(
-        "query_string", nargs="?", help="The question that will be sent to the LLM"
+        "query_string",
+        nargs="?",
+        help="The question that will be sent to the LLM",
+        default="",
     )
     question_group.add_argument(
         "-a",

--- a/tests/commands/test_chat.py
+++ b/tests/commands/test_chat.py
@@ -89,6 +89,34 @@ def test_chat_command_run_single_question(
     assert expected_output in captured.out
 
 
+@pytest.mark.parametrize(
+    (
+        "query_string",
+        "stdin",
+        "expected",
+    ),
+    (
+        ("h", "", "You query needs to have two or more characters."),
+        ("", "h", "You query needs to have two or more characters."),
+        ("h", "h", "You query needs to have two or more characters."),
+    ),
+)
+def test_chat_command_run_minimum_characters(
+    query_string,
+    stdin,
+    expected,
+    capsys,
+    default_namespace,
+):
+    default_namespace.query_string = query_string
+    default_namespace.stdin = stdin
+    command = ChatCommand(default_namespace)
+    assert command.run() == 1
+
+    captured = capsys.readouterr()
+    assert expected in captured.err.strip()
+
+
 def test_register_subcommand():
     """Test register_subcommand function"""
     parser = ArgumentParser()


### PR DESCRIPTION
If we only have one character as input from either the query_string or stdin, let's preven't it from happening as it won't provide much value.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-654](https://issues.redhat.com/browse/RSPEED-654)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
