### PR TITLE
[RSPEED-796] Disallow empty query arguments for query_string and stdin

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -539,7 +539,7 @@ class SingleQuestionOperation(BaseChatOperation):
     """Class that holds the single question ask operation"""
 
     def _validate_query(self):
-        """Helper function to validate query size.
+        """Helper function to validate query.
 
         Raises:
             ChatCommandException: In case the query has invalid sizing (less than 1 character).

--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -538,9 +538,45 @@ class InteractiveChatOperation(BaseChatOperation):
 class SingleQuestionOperation(BaseChatOperation):
     """Class that holds the single question ask operation"""
 
+    def _validate_query(self):
+        """Helper function to validate query size.
+
+        Raises:
+            ChatCommandException: In case the query has invalid sizing (less than 1 character).
+        """
+        # If both are empty, raise exception
+        if not self.args.query_string and not self.args.stdin:
+            logger.debug("Both query_string and stdin are empty.")
+            raise ChatCommandException(
+                "Your query needs to have at least 2 characters. Either query or stdin are empty."
+            )
+
+        # If query_string has content but is too short
+        if self.args.query_string and len(self.args.query_string.strip()) <= 1:
+            logger.debug(
+                "Query string has only 1 or 0 characters after stripping: '%s'",
+                self.args.query_string,
+            )
+            raise ChatCommandException(
+                "Your query needs to have at least 2 characters."
+            )
+
+        # If stdin has content but is too short
+        if self.args.stdin and len(self.args.stdin.strip()) <= 1:
+            logger.debug(
+                "Stdin has only 1 or 0 characters after stripping: '%s'",
+                self.args.stdin,
+            )
+            raise ChatCommandException(
+                "Your stdin input needs to have at least 2 characters."
+            )
+
     @timing.timeit
     def execute(self) -> None:
         """Default method to execute the operation"""
+
+        self._validate_query()
+
         try:
             last_terminal_output = ""
             if self.args.with_output:
@@ -589,16 +625,6 @@ class ChatCommand(BaseCLICommand):
         error_renderer = create_error_renderer()
         operation_factory = ChatOperationFactory()
         try:
-            if (self._args.query_string and len(self._args.query_string) <= 1) or (
-                self._args.stdin and len(self._args.stdin) <= 1
-            ):
-                logger.debug(
-                    "Either query or stdin had length 1. We require that they have at least 2 or more characters."
-                )
-                raise ChatCommandException(
-                    "You query needs to have two or more characters."
-                )
-
             operation = operation_factory.create_operation(
                 self._args,
                 self._context,

--- a/tests/commands/test_chat.py
+++ b/tests/commands/test_chat.py
@@ -96,9 +96,14 @@ def test_chat_command_run_single_question(
         "expected",
     ),
     (
-        ("h", "", "You query needs to have two or more characters."),
-        ("", "h", "You query needs to have two or more characters."),
-        ("h", "h", "You query needs to have two or more characters."),
+        (
+            "",
+            "",
+            "Your query needs to have at least 2 characters. Either query or stdin are\nempty.",
+        ),
+        ("h", "", "Your query needs to have at least 2 characters."),
+        ("", "h", "Your stdin input needs to have at least 2 characters."),
+        ("h", "h", "Your query needs to have at least 2 characters."),
     ),
 )
 def test_chat_command_run_minimum_characters(
@@ -447,6 +452,7 @@ def test_display_response(default_kwargs, capsys):
 def test_single_question_operation_with_exception(
     monkeypatch, default_kwargs, default_namespace
 ):
+    default_namespace.query_string = "test"
     default_kwargs["args"] = default_namespace
     monkeypatch.setattr(
         chat, "_read_last_terminal_output", mock.Mock(side_effect=ValueError("test"))


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-796](https://issues.redhat.com/browse/RSPEED-796)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
