### PR TITLE
[RSPEED-799] Fix dbus permissions for clad

### DIFF
--- a/data/release/dbus/com.redhat.lightspeed.conf
+++ b/data/release/dbus/com.redhat.lightspeed.conf
@@ -2,25 +2,27 @@
 <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-  <!-- Allow the command line assistant service to own the name -->
-  <policy context="default">
-    <allow own="com.redhat.lightspeed.chat"/>
-    <allow own="com.redhat.lightspeed.history"/>
-    <allow own="com.redhat.lightspeed.user"/>
+  <!-- Allow specific systemd service to own the names -->
+  <!-- This uses a combination of user and executable path -->
+  <policy user="root">
+    <allow own="com.redhat.lightspeed.chat" if_selinux_context="system_u:system_r:clad_t:s0"/>
+    <allow own="com.redhat.lightspeed.history" if_selinux_context="system_u:system_r:clad_t:s0"/>
+    <allow own="com.redhat.lightspeed.user" if_selinux_context="system_u:system_r:clad_t:s0"/>
+
+    <!-- Allow only clad executable to own the bus names -->
+    <allow own="com.redhat.lightspeed.chat" own_prefix="com.redhat.lightspeed" send_path="/usr/sbin/clad"/>
+    <allow own="com.redhat.lightspeed.history" own_prefix="com.redhat.lightspeed" send_path="/usr/sbin/clad"/>
+    <allow own="com.redhat.lightspeed.user" own_prefix="com.redhat.lightspeed" send_path="/usr/sbin/clad"/>
   </policy>
 
   <!-- Allow any user to invoke methods -->
   <policy context="default">
     <allow send_destination="com.redhat.lightspeed.chat"/>
     <allow receive_sender="com.redhat.lightspeed.chat"/>
-  </policy>
 
-  <policy context="default">
     <allow send_destination="com.redhat.lightspeed.history"/>
     <allow receive_sender="com.redhat.lightspeed.history"/>
-  </policy>
 
-  <policy context="default">
     <allow send_destination="com.redhat.lightspeed.user"/>
     <allow receive_sender="com.redhat.lightspeed.user"/>
   </policy>


### PR DESCRIPTION
Currently, the dbus policies were too open. We let all users acquire the bus name, which can be problematic.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-799](https://issues.redhat.com/browse/RSPEED-799)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
