### PR TITLE
Remove selinux context from dbus policy

### DIFF
--- a/data/release/dbus/com.redhat.lightspeed.conf
+++ b/data/release/dbus/com.redhat.lightspeed.conf
@@ -2,17 +2,11 @@
 <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-  <!-- Allow specific systemd service to own the names -->
-  <!-- This uses a combination of user and executable path -->
+  <!-- Allow only root user to take acquire the com.redhat.lightspeed.* names -->
   <policy user="root">
-    <allow own="com.redhat.lightspeed.chat" if_selinux_context="system_u:system_r:clad_t:s0"/>
-    <allow own="com.redhat.lightspeed.history" if_selinux_context="system_u:system_r:clad_t:s0"/>
-    <allow own="com.redhat.lightspeed.user" if_selinux_context="system_u:system_r:clad_t:s0"/>
-
-    <!-- Allow only clad executable to own the bus names -->
-    <allow own="com.redhat.lightspeed.chat" own_prefix="com.redhat.lightspeed" send_path="/usr/sbin/clad"/>
-    <allow own="com.redhat.lightspeed.history" own_prefix="com.redhat.lightspeed" send_path="/usr/sbin/clad"/>
-    <allow own="com.redhat.lightspeed.user" own_prefix="com.redhat.lightspeed" send_path="/usr/sbin/clad"/>
+    <allow own="com.redhat.lightspeed.chat"/>
+    <allow own="com.redhat.lightspeed.history"/>
+    <allow own="com.redhat.lightspeed.user"/>
   </policy>
 
   <!-- Allow any user to invoke methods -->


### PR DESCRIPTION
This field is not present in RHEL 9.6, so we are removing it from here.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
