### PR TITLE
[RSPEED-812] Add exception handling for RuntimeError

### DIFF
--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -170,10 +170,17 @@ def test_initialize_command_selection(argv, expected_command):
         mock_command.assert_called_once()
 
 
-def test_dbus_initialization_error(capsys):
+@pytest.mark.parametrize(
+    ("exception", "expected"),
+    (
+        (DBusError, "Name is not active"),
+        (RuntimeError, "Oops! Something went wrong while processing your request."),
+    ),
+)
+def test_exception_initialization_error(exception, expected, capsys):
     with patch("command_line_assistant.initialize.read_stdin") as mock_stdin:
-        mock_stdin.side_effect = DBusError("Name is not active")
+        mock_stdin.side_effect = exception(expected)
         initialize()
 
     captured = capsys.readouterr()
-    assert "Name is not active" in captured.err
+    assert expected in captured.err


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-812](https://issues.redhat.com/browse/RSPEED-812)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
