### PR TITLE
Ignore .python-version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *.egg-info
 .vscode/
 .idea
+.python-version
 
 # ignore thirdy-party tool caches
 .ruff_cache


### PR DESCRIPTION
pyenv uses a ".python-version" file to track the version of python to use when in the current directory.