### PR TITLE
[RSPEED-816] Add support for plain, simple output

### DIFF
--- a/command_line_assistant/client.py
+++ b/command_line_assistant/client.py
@@ -46,8 +46,13 @@ def main() -> int:
         int: Status code of the execution
     """
     parser = register_subcommands()
-    error_renderer = create_error_renderer()
-    warning_renderer = create_warning_renderer()
+
+    # Create the error and warning renderers, checking very early if the user
+    # specified the --plain flag. This allows the exceptions below that use
+    # these renders to follow the user's preference.
+    plain_in_argv = "-p" in sys.argv or "--plain" in sys.argv
+    error_renderer = create_error_renderer(plain=plain_in_argv)
+    warning_renderer = create_warning_renderer(plain=plain_in_argv)
 
     try:
         stdin = read_stdin()
@@ -60,6 +65,13 @@ def main() -> int:
         if not hasattr(args, "func"):
             parser.print_help()
             return os.EX_USAGE
+
+        error_renderer = create_error_renderer(
+            plain=hasattr(args, "plain") and args.plain
+        )
+        warning_renderer = create_warning_renderer(
+            plain=hasattr(args, "plain") and args.plain
+        )
 
         # In case the uder specify the --debug, we will enable the logging here.
         if args.debug:

--- a/command_line_assistant/commands/base.py
+++ b/command_line_assistant/commands/base.py
@@ -204,9 +204,15 @@ class CommandOperationFactory:
             logger.warning("No operation registered for type %s", operation_type)
             return None
 
-        text_renderer = text_renderer or create_text_renderer()
-        warning_renderer = warning_renderer or create_warning_renderer()
-        error_renderer = error_renderer or create_error_renderer()
+        text_renderer = text_renderer or create_text_renderer(
+            plain=hasattr(args, "plain") and args.plain
+        )
+        warning_renderer = warning_renderer or create_warning_renderer(
+            plain=hasattr(args, "plain") and args.plain
+        )
+        error_renderer = error_renderer or create_error_renderer(
+            plain=hasattr(args, "plain") and args.plain
+        )
 
         # Type Ignoring the parameters as they do exist in the baes class.
         return operation_class(

--- a/command_line_assistant/commands/feedback.py
+++ b/command_line_assistant/commands/feedback.py
@@ -12,17 +12,10 @@ from command_line_assistant.commands.base import (
     CommandOperationFactory,
     CommandOperationType,
 )
-from command_line_assistant.exceptions import (
-    FeedbackCommandException,
-)
+from command_line_assistant.exceptions import FeedbackCommandException
 from command_line_assistant.rendering.renders.text import TextRenderer
-from command_line_assistant.utils.cli import (
-    SubParsersAction,
-    create_subparser,
-)
-from command_line_assistant.utils.renderers import (
-    create_error_renderer,
-)
+from command_line_assistant.utils.cli import SubParsersAction, create_subparser
+from command_line_assistant.utils.renderers import create_error_renderer
 
 WARNING_MESSAGE = "Do not include any personal information or other sensitive information in your feedback. Feedback may be used to improve Red Hat's products or services."
 
@@ -69,7 +62,9 @@ class FeedbackCommand(BaseCLICommand):
         Returns:
             int: Return the status code for the operation
         """
-        error_renderer: TextRenderer = create_error_renderer()
+        error_renderer: TextRenderer = create_error_renderer(
+            plain=hasattr(self._args, "plain") and self._args.plain
+        )
         operation_factory = FeedbackOperationFactory()
         try:
             # Get and execute the appropriate operation

--- a/command_line_assistant/commands/history.py
+++ b/command_line_assistant/commands/history.py
@@ -123,7 +123,9 @@ class BaseHistoryOperation(BaseOperation):
             user_proxy,
         )
         # Add markdown renderer as a standard renderer
-        self.markdown_renderer = create_markdown_renderer()
+        self.markdown_renderer = create_markdown_renderer(
+            plain=hasattr(args, "plain") and args.plain
+        )
 
     def _show_history(self, entries: HistoryList) -> None:
         """Internal method to show the history in a standardized way
@@ -139,19 +141,22 @@ class BaseHistoryOperation(BaseOperation):
         question_renderer = create_markdown_renderer(
             decorators=[
                 ColorDecorator(foreground="cyan"),
-            ]
+            ],
+            plain=hasattr(self.args, "plain") and self.args.plain,
         )
 
         answer_renderer = create_markdown_renderer(
             decorators=[
                 ColorDecorator(foreground="green"),
-            ]
+            ],
+            plain=hasattr(self.args, "plain") and self.args.plain,
         )
 
         metadata_renderer = create_text_renderer(
             decorators=[
                 ColorDecorator(foreground="yellow"),
-            ]
+            ],
+            plain=hasattr(self.args, "plain") and self.args.plain,
         )
 
         for entry in entries.histories:
@@ -343,7 +348,9 @@ class HistoryCommand(BaseCLICommand):
         Returns:
             int: Status code of the execution.
         """
-        error_renderer: TextRenderer = create_error_renderer()
+        error_renderer: TextRenderer = create_error_renderer(
+            plain=hasattr(self._args, "plain") and self._args.plain
+        )
         operation_factory = HistoryOperationFactory()
         try:
             operation = operation_factory.create_operation(

--- a/command_line_assistant/rendering/renders/markdown.py
+++ b/command_line_assistant/rendering/renders/markdown.py
@@ -240,3 +240,15 @@ class MarkdownRenderer(BaseRenderer):
         final_text = "".join(block for block in processed_blocks if block)
         if final_text:
             self._stream.execute(final_text)
+
+
+class PlainMarkdownRenderer(MarkdownRenderer):
+    """Renders markdown-formatted text to the terminal without any styling."""
+
+    def render(self, text: str) -> None:
+        """Render markdown text to the terminal without any formatting.
+
+        Args:
+            text (str): Markdown text to render
+        """
+        self._stream.execute(text)

--- a/command_line_assistant/rendering/renders/spinner.py
+++ b/command_line_assistant/rendering/renders/spinner.py
@@ -199,3 +199,21 @@ class SpinnerRenderer(BaseRenderer):
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """The special contextmanager method to stop the spinner."""
         self.stop()
+
+
+class StaticSpinnerRenderer(SpinnerRenderer):
+    """A spinner renderer that does not animate."""
+
+    def __enter__(self) -> "StaticSpinnerRenderer":
+        """The special contextmanager method to start the "spinner".
+
+        Returns:
+            StaticSpinnerRenderer: Return itself.
+        """
+
+        self._stream.execute(f"{next(self._frames)} {self._message}")
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """The special contextmanager method to stop the "spinner"."""
+        self._stream.execute("\n")

--- a/command_line_assistant/rendering/renders/text.py
+++ b/command_line_assistant/rendering/renders/text.py
@@ -35,3 +35,17 @@ class TextRenderer(BaseRenderer):
         for line in lines:
             decorated_text = self._apply_decorators(line)
             self._stream.execute(decorated_text)
+
+
+class PlainTextRenderer(TextRenderer):
+    """Specialized class to render plain text output without any decorations"""
+
+    def render(self, text: str) -> None:
+        """The main function to render the text.
+
+        Arguments:
+            text (str): The textual value that will be represented in the terminal.
+        """
+        lines = text.splitlines()
+        for line in lines:
+            self._stream.execute(line)

--- a/command_line_assistant/utils/cli.py
+++ b/command_line_assistant/utils/cli.py
@@ -18,7 +18,15 @@ from command_line_assistant.constants import VERSION
 # Define the type here so pyright is happy with it.
 SubParsersAction = _SubParsersAction
 
-GLOBAL_FLAGS: list[str] = ["--debug", "--version", "-v", "-h", "--help"]
+GLOBAL_FLAGS: list[str] = [
+    "-p",
+    "--plain",
+    "--debug",
+    "--version",
+    "-v",
+    "-h",
+    "--help",
+]
 ARGS_WITH_VALUES: list[str] = ["--clear"]
 
 OS_RELEASE_PATH = Path("/etc/os-release")
@@ -142,6 +150,12 @@ def create_argument_parser() -> tuple[ArgumentParser, SubParsersAction]:
         version=VERSION,
         default=SUPPRESS,
         help="Show program version",
+    )
+    parser.add_argument(
+        "-p",
+        "--plain",
+        action="store_true",
+        help="Enable plain output. This will disable colors, animations, and other rich content.",
     )
     commands_parser = parser.add_subparsers(dest="command")
     return parser, commands_parser

--- a/command_line_assistant/utils/cli.py
+++ b/command_line_assistant/utils/cli.py
@@ -155,7 +155,8 @@ def create_argument_parser() -> tuple[ArgumentParser, SubParsersAction]:
         "-p",
         "--plain",
         action="store_true",
-        help="Enable plain output. This will disable colors, animations, and other rich content.",
+        help=argparse.SUPPRESS,
+        default=True,
     )
     commands_parser = parser.add_subparsers(dest="command")
     return parser, commands_parser

--- a/command_line_assistant/utils/renderers.py
+++ b/command_line_assistant/utils/renderers.py
@@ -10,14 +10,27 @@ from command_line_assistant.rendering.decorators.text import (
     TextWrapDecorator,
 )
 from command_line_assistant.rendering.renders.interactive import InteractiveRenderer
-from command_line_assistant.rendering.renders.markdown import MarkdownRenderer
-from command_line_assistant.rendering.renders.spinner import SpinnerRenderer
-from command_line_assistant.rendering.renders.text import TextRenderer
+from command_line_assistant.rendering.renders.markdown import (
+    MarkdownRenderer,
+    PlainMarkdownRenderer,
+)
+from command_line_assistant.rendering.renders.spinner import (
+    SpinnerRenderer,
+    StaticSpinnerRenderer,
+)
+from command_line_assistant.rendering.renders.text import (
+    PlainTextRenderer,
+    TextRenderer,
+)
 from command_line_assistant.rendering.stream import StderrStream, StdoutStream
 
 
-def create_error_renderer() -> TextRenderer:
+def create_error_renderer(plain: bool = False) -> TextRenderer:
     """Create a standardized instance of text rendering for error output
+
+    Arguments:
+        plain (bool): If True, it will create a plain text renderer without any
+        decorations. Defaults to False.
 
     Returns:
         TextRenderer: Instance of a TextRenderer with correct decorators for
@@ -29,13 +42,18 @@ def create_error_renderer() -> TextRenderer:
             ColorDecorator(foreground="red"),
         ],
         StderrStream(),
+        plain=plain,
     )
 
     return renderer
 
 
-def create_warning_renderer() -> TextRenderer:
+def create_warning_renderer(plain: bool = False) -> TextRenderer:
     """Create a standardized instance of text rendering for error output
+
+    Arguments:
+        plain (bool): If True, it will create a plain text renderer without any
+        decorations. Defaults to False.
 
     Returns:
         TextRenderer: Instance of a TextRenderer with correct decorators for
@@ -47,13 +65,14 @@ def create_warning_renderer() -> TextRenderer:
             ColorDecorator(foreground="yellow"),
         ],
         StderrStream(),
+        plain=plain,
     )
 
     return renderer
 
 
 def create_spinner_renderer(
-    message: str, decorators: Optional[list[BaseDecorator]] = None
+    message: str, decorators: Optional[list[BaseDecorator]] = None, plain: bool = False
 ) -> SpinnerRenderer:
     """Create a new instance of a spinner renderer.
 
@@ -68,7 +87,11 @@ def create_spinner_renderer(
     Returns:
         SpinnerRenderer: Instance of a SpinnerRenderer with decorators applied.
     """
-    spinner = SpinnerRenderer(message, stream=StdoutStream(end=""))
+    spinner = (
+        StaticSpinnerRenderer(message, stream=StdoutStream(end=""))
+        if plain
+        else SpinnerRenderer(message, stream=StdoutStream(end=""))
+    )
     decorators = decorators or []
     decorators.append(TextWrapDecorator())
     spinner.update(decorators)
@@ -90,6 +113,7 @@ def create_interactive_renderer() -> InteractiveRenderer:
 def create_text_renderer(
     decorators: Optional[list[BaseDecorator]] = None,
     stream: Optional[BaseStream] = None,
+    plain: bool = False,
 ) -> TextRenderer:
     """Create a new instance of a text renderer.
 
@@ -104,6 +128,8 @@ def create_text_renderer(
         decorators that can be applied to the text renderer. Defaults to None.
         stream (Optional[BaseStream], optional): Apply a different stream other
         than the StdoutStream. Defaults to None.
+        plain (bool): If True, it will create a plain text renderer without any
+        decorations. Defaults to False.
 
     Returns:
         TextRenderer: Instance of a TextRenderer with decorators applied.
@@ -111,7 +137,7 @@ def create_text_renderer(
     # In case it is None, default it to an empty list.
     decorators = decorators or []
 
-    text = TextRenderer(stream=stream)
+    text = PlainTextRenderer(stream=stream) if plain else TextRenderer(stream=stream)
     decorators.append(TextWrapDecorator())
     text.update(decorators)
 
@@ -140,6 +166,7 @@ def human_readable_size(size: float) -> str:
 def create_markdown_renderer(
     decorators: Optional[list[BaseDecorator]] = None,
     stream: Optional[BaseStream] = None,
+    plain: bool = False,
 ) -> MarkdownRenderer:
     """Create a new instance of a markdown renderer.
 
@@ -148,12 +175,18 @@ def create_markdown_renderer(
             that can be applied to the markdown renderer. Defaults to None.
         stream (Optional[BaseStream], optional): Apply a different stream other
             than the StdoutStream. Defaults to None.
+        plain (bool): If True, it will create a plain markdown renderer without
+        any decorations. Defaults to False.
 
     Returns:
         MarkdownRenderer: Instance of a MarkdownRenderer with decorators applied.
     """
     decorators = decorators or []
-    markdown = MarkdownRenderer(stream=stream)
+    markdown = (
+        PlainMarkdownRenderer(stream=stream)
+        if plain
+        else MarkdownRenderer(stream=stream)
+    )
     decorators.append(TextWrapDecorator())
     markdown.update(decorators)
     return markdown

--- a/data/release/man/c.1
+++ b/data/release/man/c.1
@@ -79,6 +79,8 @@ c chat [\-h] [\-a [ATTACHMENT]] [\-i] [\-w [WITH_OUTPUT]] [\-r] [\-l] [\-d [DELE
 .IP \(bu 2
 \fI\%\-w\fP \fBWITH_OUTPUT\fP, \fI\%\-\-with\-output\fP \fBWITH_OUTPUT\fP \- Add output from terminal as context for the query. Use 1 to retrieve the latest output, 2 to and so on. First, enable the terminal capture with \fB\(aqc shell \-\-enable\-capture\(aq\fP for this option to work. (default: \fBNone\fP)
 .IP \(bu 2
+\fI\%\-w\fP \fBWITH_OUTPUT\fP, \fI\%\-\-with\-output\fP \fBWITH_OUTPUT\fP \- Add output from terminal as context for the query. Use 1 to retrieve latest output, 2 to before last and so on... First enable the terminal capture with \fB\(aqc shell \-\-enable\-capture\(aq\fP in order for this to work. (default: \fBNone\fP)
+.IP \(bu 2
 \fI\%\-r\fP, \fI\%\-\-plain\fP \- Enable plain output. This will disable colors, animations, and other rich content.
 .UNINDENT
 .SS c chat Chat Options

--- a/data/release/man/c.1
+++ b/data/release/man/c.1
@@ -79,7 +79,7 @@ c chat [\-h] [\-a [ATTACHMENT]] [\-i] [\-w [WITH_OUTPUT]] [\-r] [\-l] [\-d [DELE
 .IP \(bu 2
 \fI\%\-w\fP \fBWITH_OUTPUT\fP, \fI\%\-\-with\-output\fP \fBWITH_OUTPUT\fP \- Add output from terminal as context for the query. Use 1 to retrieve the latest output, 2 to and so on. First, enable the terminal capture with \fB\(aqc shell \-\-enable\-capture\(aq\fP for this option to work. (default: \fBNone\fP)
 .IP \(bu 2
-\fI\%\-r\fP, \fI\%\-\-raw\fP \- Interact with the backend in raw mode. No spinners, emojis or anything.
+\fI\%\-r\fP, \fI\%\-\-plain\fP \- Enable plain output. This will disable colors, animations, and other rich content.
 .UNINDENT
 .SS c chat Chat Options
 .INDENT 0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ testpaths = ["tests"]
 
 [tool.coverage.report]
 skip_empty = true
+exclude_also = ["if __name__ == \"__main__\":"]
 
 [tool.coverage.run]
 branch = true

--- a/tests/commands/test_chat.py
+++ b/tests/commands/test_chat.py
@@ -49,7 +49,7 @@ def default_namespace():
         name="test",
         description="test",
         with_output=None,
-        raw=False,
+        plain=False,
     )
 
 

--- a/tests/rendering/renders/test_markdown.py
+++ b/tests/rendering/renders/test_markdown.py
@@ -1,7 +1,10 @@
 import pytest
 
 from command_line_assistant.rendering.base import BaseStream
-from command_line_assistant.rendering.renders.markdown import MarkdownRenderer
+from command_line_assistant.rendering.renders.markdown import (
+    MarkdownRenderer,
+    PlainMarkdownRenderer,
+)
 
 
 class MockStream(BaseStream):
@@ -20,6 +23,11 @@ def mock_stream():
 @pytest.fixture
 def markdown_renderer(mock_stream):
     return MarkdownRenderer(mock_stream)
+
+
+@pytest.fixture
+def plain_markdown_renderer(mock_stream):
+    return PlainMarkdownRenderer(mock_stream)
 
 
 def test_basic_text_rendering(markdown_renderer):
@@ -167,3 +175,12 @@ def test_markdown_renderer_with_different_header_levels(markdown_renderer):
     assert "LEVEL 1 HEADER" in output  # Level 1 headers are uppercase
     assert "Level 2 Header" in output  # Level 2 headers have underlines
     assert "Level 3 Header" in output  # Level 3 headers have dot underlines
+
+
+def test_plain_markdown_renderer(plain_markdown_renderer):
+    """Test the plain markdown renderer"""
+    text = "This is **bold** and *italic* text"
+    plain_markdown_renderer.render(text)
+    assert (
+        "This is **bold** and *italic* text" in plain_markdown_renderer._stream.output
+    )

--- a/tests/rendering/renders/test_text.py
+++ b/tests/rendering/renders/test_text.py
@@ -4,7 +4,10 @@ from command_line_assistant.rendering.decorators.text import (
     EmojiDecorator,
     TextWrapDecorator,
 )
-from command_line_assistant.rendering.renders.text import TextRenderer
+from command_line_assistant.rendering.renders.text import (
+    PlainTextRenderer,
+    TextRenderer,
+)
 
 
 def test_text_renderer_multiple_decorators():
@@ -109,3 +112,24 @@ def test_text_renderer_with_mixed_decorators(mock_stream):
     assert "\x1b[1m" in output  # Bright style
     assert "\x1b[32m" in output  # Green color
     assert "  " in output  # Indentation
+
+
+def test_plain_text_renderer_with_decorators(mock_stream):
+    """Test plain text renderer with decorators"""
+    renderer = PlainTextRenderer(stream=mock_stream)
+    renderer.update(
+        [
+            ColorDecorator(foreground="green"),
+            StyleDecorator("bright"),
+            EmojiDecorator("🔍"),
+        ]
+    )
+
+    renderer.render("This is a long text that should be undecorated")
+
+    # Check that no decorations were applied
+    output = "".join(mock_stream.written)
+    assert "🔍" not in output  # Emoji
+    assert "\x1b[1m" not in output  # Bright style
+    assert "\x1b[32m" not in output  # Green color
+    assert "This is a long text that should be undecorated" in output


### PR DESCRIPTION
PlainTextRenderer and PlainMarkdownRenderer subclass TextRenderer and MarkdownRenderer respectively. They disregard any decorators that might be added to them by other code and print plain text or raw, unformatted markdown as the case may be.

The various renderer factory functions (create_text_renderer and create_markdown_renderer) have been updated with a keyword argument of 'plain' with a default value of false (preserving existing behavior). If plain is true, the factory function returns a Plain subclass instead of the rich-formatted class. The rest of the render flow remains unmodified. The various calls to create_text_renderer and create_markdown_renderer function have been updated to pass in the value of 'args.plain' wherever possible. This will enable plain rendering when the --plain flag is passed at the commandline. The --plain flag is also moved up from the chat subcommand to the base argument parser. This enables 'plain' functionality in history and feedback too.

Notably, the emoji in the history output is not stripped out by the PlainMarkdownRenderer as it is not inserted by a decorator. It is added directly into the text output.

There is a rider commit on this PR that allows `c` to be run as a module; this speeds up debugging. It doesn't need to be squashed.

![RSPEED-816_plain_text](https://github.com/user-attachments/assets/413cfb96-1c87-4d54-815b-4116ac73c5bd)

- Fixes [RSPEED-816](https://issues.redhat.com/browse/RSPEED-816)
- Fixes [RSPEED-766](https://issues.redhat.com/browse/RSPEED-766)
