### PR TITLE
[RSPEED-768] Fix '.exit' from interactive mode

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -530,8 +530,12 @@ class InteractiveChatOperation(BaseChatOperation):
                     skip_spinner=self.args.raw,
                 )
                 self._display_response(response)
-        except StopInteractiveMode as e:
-            raise ChatCommandException(str(e)) from e
+        except (KeyboardInterrupt, EOFError) as e:
+            raise ChatCommandException(
+                "Detected keyboard interrupt. Stopping interactive mode."
+            ) from e
+        except StopInteractiveMode:
+            return
 
 
 @ChatOperationFactory.register(ChatOperationType.SINGLE_QUESTION)

--- a/command_line_assistant/rendering/renders/interactive.py
+++ b/command_line_assistant/rendering/renders/interactive.py
@@ -46,18 +46,13 @@ class InteractiveRenderer(BaseRenderer):
             self._stream.write("The current session does not include running context.")
             self._first_message = True
 
-        try:
-            user_input = input(text).strip()
+        user_input = input(text).strip()
 
-            # More commands can be added in the future, but for now, we only have .exit
-            if user_input == ".exit":
-                raise StopInteractiveMode("Stopping interactive mode.")
+        # More commands can be added in the future, but for now, we only have .exit
+        if user_input == ".exit":
+            raise StopInteractiveMode("Stopping interactive mode.")
 
-            self.output = user_input
-        except (KeyboardInterrupt, EOFError) as e:
-            raise StopInteractiveMode(
-                "Detected keyboard interrupt. Stopping interactive mode."
-            ) from e
+        self.output = user_input
 
     @property
     def output(self) -> str:

--- a/tests/rendering/renders/test_interactive.py
+++ b/tests/rendering/renders/test_interactive.py
@@ -37,26 +37,6 @@ def test_interactive_renderer_exit_command(mock_input, interactive_renderer):
         interactive_renderer.render(">>> ")
 
 
-@patch("builtins.input", side_effect=KeyboardInterrupt)
-def test_interactive_renderer_keyboard_interrupt(mock_input, interactive_renderer):
-    """Test that KeyboardInterrupt raises StopInteractiveMode"""
-    with pytest.raises(
-        StopInteractiveMode,
-        match="Detected keyboard interrupt. Stopping interactive mode.",
-    ):
-        interactive_renderer.render(">>> ")
-
-
-@patch("builtins.input", side_effect=EOFError)
-def test_interactive_renderer_eof_error(mock_input, interactive_renderer):
-    """Test that EOFError raises StopInteractiveMode"""
-    with pytest.raises(
-        StopInteractiveMode,
-        match="Detected keyboard interrupt. Stopping interactive mode.",
-    ):
-        interactive_renderer.render(">>> ")
-
-
 def test_interactive_renderer_banner_display(capsys):
     """Test that interactive renderer displays banner on first render"""
     banner = "Welcome to test interactive mode!"


### PR DESCRIPTION
The '.exit' operation was killing the process with exit code as 1, which is not ideal and correct. This patch fix it to exit with 0 instead.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-768](https://issues.redhat.com/browse/RSPEED-768)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
