### PR TITLE
[RSPEED-829] Add check in clear(-all) to check if there is any chat to clean

### DIFF
--- a/command_line_assistant/dbus/interfaces/chat.py
+++ b/command_line_assistant/dbus/interfaces/chat.py
@@ -128,6 +128,33 @@ class ChatInterface(InterfaceTemplate):
         result = self._chat_repository.select_latest_chat(user_id)
         return str(result.id)
 
+    def IsChatAvailable(self, user_id: Str, name: Str) -> bool:
+        """Check if a chat session is available for a given user.
+
+        Arguments:
+            user_id (Str): The identifier of the user.
+            name (Str): The name of the chat.
+
+        Returns:
+            bool: True if the chat session is available, False otherwise.
+        """
+        result = self._chat_repository.select_by_name(user_id, name)
+
+        if not result:
+            logger.info(
+                "Chat session with name '%s' not found for user '%s'.",
+                name,
+                user_id,
+            )
+            return False
+
+        logger.info(
+            "Chat session with name '%s' found for user '%s'.",
+            name,
+            user_id,
+        )
+        return True
+
     def GetChatId(self, user_id: Str, name: Str) -> Str:
         """Get the chat id for a given user and chat name.
 

--- a/tests/dbus/interfaces/test_chat.py
+++ b/tests/dbus/interfaces/test_chat.py
@@ -125,8 +125,35 @@ def test_get_chat_id_exception(chat_interface):
         chat_interface.GetChatId(uid, "test")
 
 
-def test_create_chat(chat_interface, caplog):
+def test_create_chat(
+    chat_interface,
+):
     uid = "2345f9e6-dfea-11ef-9ae9-52b437312584"
     result = chat_interface.CreateChat(uid, "test", "test")
     assert result
     assert "-" in result
+
+
+@pytest.mark.parametrize(
+    ("available", "name", "expected"), ((True, "test", True), (False, "test", False))
+)
+def test_is_chat_available(
+    chat_interface, mock_repository, caplog, available, name, expected
+):
+    uid = "2345f9e6-dfea-11ef-9ae9-52b437312584"
+    chat_interface.IsChatAvailable(uid, name)
+    if available:
+        mock_repository.insert({"name": name, "description": "test", "user_id": uid})
+
+    result = chat_interface.IsChatAvailable(uid, name)
+    assert result == expected
+    if available:
+        assert (
+            f"Chat session with name '{name}' found for user '{uid}'."
+            in caplog.records[-1].message
+        )
+    else:
+        assert (
+            f"Chat session with name '{name}' not found for user '{uid}'."
+            in caplog.records[-1].message
+        )


### PR DESCRIPTION
In this patch, we are adding a call to the chat bus to figure out if there is any chat available with a given name for a user.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-829](https://issues.redhat.com/browse/RSPEED-829)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
