### PR TITLE
[RSPEED-859] Prevent abbrev in argparse

### DIFF
--- a/command_line_assistant/utils/cli.py
+++ b/command_line_assistant/utils/cli.py
@@ -187,6 +187,9 @@ def create_subparser(parser: SubParsersAction, name: str, help: str) -> Argument
         name,
         help=help,
         add_help=False,
+        # If allow_abbrev is set to True, then we can use --from instead of
+        # --from-chat, for example.
+        allow_abbrev=False,
     )
     custom_parser.add_argument(
         "-h",

--- a/command_line_assistant/utils/cli.py
+++ b/command_line_assistant/utils/cli.py
@@ -187,8 +187,7 @@ def create_subparser(parser: SubParsersAction, name: str, help: str) -> Argument
         name,
         help=help,
         add_help=False,
-        # If allow_abbrev is set to True, then we can use --from instead of
-        # --from-chat, for example.
+        # Disable abbreviated argument matching. This prevents partial strings from matching to valid options (for example, --from matching to --from-chat).
         allow_abbrev=False,
     )
     custom_parser.add_argument(


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-859](https://issues.redhat.com/browse/RSPEED-859)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
