### PR TITLE
[RSPEED-817] Add label automation to help in release changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,32 @@
+changelog:
+  exclude:
+    labels:
+      - skip/changelog
+    authors:
+      - dependabot
+      - pre-commit-ci
+      - renovate
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - kind/breaking
+        - breaking-change
+    - title: Enhancements 🎉
+      labels:
+        - kind/feature
+        - enhancement
+    - title: Security Hardening 🔒
+      labels:
+        - kind/security
+        - security-hardening
+    - title: Bug Fixes 🐛
+      labels:
+        - kind/bug-fix
+        - bug-fix
+    - title: Test Coverage Enhancements 🔧
+      labels:
+        - kind/tests
+        - test-coverage-enhancement
+    - title: Other Changes
+      labels:
+        - "kind/*"

--- a/.github/workflows/enforce_labels.yml
+++ b/.github/workflows/enforce_labels.yml
@@ -1,0 +1,17 @@
+name: Require PR labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  require-type-label:
+    if: ${{ !contains(fromJson('["dependabot", "pre-commit-ci", "renovate"]'), github.actor ) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: "kind/.*"
+          use_regex: true

--- a/.github/workflows/jira-links.yml
+++ b/.github/workflows/jira-links.yml
@@ -1,0 +1,43 @@
+---
+name: Handle release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update_jira_links:
+    name: Update Jira links
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Get release content
+        run: gh release view ${{github.ref_name}} --json body --jq '.body' > releaseBody.txt
+
+      - name: Add Jira links
+        shell: python
+        run: |
+          import re
+
+          #  RegEx explained
+          # (?<!\/) Negative lookbehind of / to avoid grabbing URLs
+          # ((?:RHELC?|HMS)-\d+) Get RSPED or RHEL keys, add to a group
+          # \b Word boundary to indicate this should be the end of the match
+          # (?!\]\() Negative lookahead of ]( to prevent Jira keys in markdown links
+          regex=re.compile(r"(?<!\/)((?:RPSEED|RHEL)-\d+)\b(?!\]\()", re.MULTILINE)
+          with open("releaseBody.txt", 'r+') as f:
+            data = f.read()
+            f.seek(0)
+            # RegEx explained
+            # Replace the grabbed Jira key with a Markdown link [key](i.r.c/browse/key)
+            # [\g<0>] Add the Jira key group 0, equivalent of \1
+            # (https://issues.redhat.com/browse/\g<0>) Add the Jira key group 0, equivalent of \1, to end of URL
+            body = regex.sub(r"[\g<0>](https://issues.redhat.com/browse/\g<0>)", data)
+            f.write(body)
+            f.truncate()
+
+      - name: Update release body with Jira links
+        run: gh release edit ${{github.ref_name}} --notes-file releaseBody.txt


### PR DESCRIPTION
This patch introduces some workflows to help us identify which PRs are necessary to push in a changelog or not. With the labels tagging, we can filter out PRs that does not need to be included in the changelog.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-817](https://issues.redhat.com/browse/RSPEED-817)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
