### PR TITLE
Remove redundant exception message

### DIFF
--- a/command_line_assistant/rendering/renders/interactive.py
+++ b/command_line_assistant/rendering/renders/interactive.py
@@ -50,7 +50,7 @@ class InteractiveRenderer(BaseRenderer):
 
         # More commands can be added in the future, but for now, we only have .exit
         if user_input == ".exit":
-            raise StopInteractiveMode("Stopping interactive mode.")
+            raise StopInteractiveMode
 
         self.output = user_input
 

--- a/tests/rendering/renders/test_interactive.py
+++ b/tests/rendering/renders/test_interactive.py
@@ -33,7 +33,7 @@ def test_interactive_renderer_input(mock_input, interactive_renderer):
 @patch("builtins.input", return_value=".exit")
 def test_interactive_renderer_exit_command(mock_input, interactive_renderer):
     """Test that .exit command raises StopInteractiveMode"""
-    with pytest.raises(StopInteractiveMode, match="Stopping interactive mode."):
+    with pytest.raises(StopInteractiveMode):
         interactive_renderer.render(">>> ")
 
 


### PR DESCRIPTION
* With #301 patch the StopInteractiveMode exception gets handled explicitly with an intention to not do anything else with it
* The exception message is now redundant due to that and might cause unnecessary confusion

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
