### PR TITLE
[RSPEED-925] Update colors in MarkdownRenderer to make the text more visible

### DIFF
--- a/command_line_assistant/rendering/renders/markdown.py
+++ b/command_line_assistant/rendering/renders/markdown.py
@@ -27,8 +27,9 @@ CODE_BLOCK_MARKER = "```"
 SECTION_WIDTH: int = 16
 
 # Color decorators for terminal output
-HIGHLIGHT_DEFAULT_COLOR: ColorDecorator = ColorDecorator(foreground="lightblue")
-LLM_RESPONSE_COLOR: ColorDecorator = ColorDecorator(foreground="red")
+CODEBLOCK_HIGHLIGHT_COLOR: ColorDecorator = ColorDecorator(foreground="lightcyan")
+LLM_RESPONSE_COLOR: ColorDecorator = ColorDecorator(foreground="white")
+HEADER_HIGHLIGHT_COLOR: ColorDecorator = ColorDecorator(foreground="lightblack")
 
 
 @dataclass
@@ -91,8 +92,8 @@ class MarkdownRenderer(BaseRenderer):
             str: Formatted section header
         """
         if language:
-            title = f"{HIGHLIGHT_DEFAULT_COLOR.decorate(f'[{language}]')} {title}"
-        return f"{title} {'─' * SECTION_WIDTH}"
+            title = f"'[{language}]' {title}"
+        return HEADER_HIGHLIGHT_COLOR.decorate(f"{title} {'─' * SECTION_WIDTH}")
 
     def _process_inline_formatting(self, text: str) -> str:
         """Process inline markdown formatting (bold, italic, code, links).
@@ -114,11 +115,11 @@ class MarkdownRenderer(BaseRenderer):
             ),
             (
                 INLINE_CODE_REGEX,
-                lambda m: f"{HIGHLIGHT_DEFAULT_COLOR.decorate(m.group(1))}{LLM_RESPONSE_COLOR.start()}",
+                lambda m: f"{CODEBLOCK_HIGHLIGHT_COLOR.decorate(m.group(1))}{LLM_RESPONSE_COLOR.start()}",
             ),
             (
                 HANDLE_LINKS_REGEX,
-                lambda m: f"{m.group(1)} ({HIGHLIGHT_DEFAULT_COLOR.decorate(m.group(2))}){LLM_RESPONSE_COLOR.start()}",
+                lambda m: f"{m.group(1)} ({CODEBLOCK_HIGHLIGHT_COLOR.decorate(m.group(2))}){LLM_RESPONSE_COLOR.start()}",
             ),
         ]
 
@@ -141,8 +142,8 @@ class MarkdownRenderer(BaseRenderer):
         header = self._format_section_header(title, language)
         content = content.strip().lstrip("$").lstrip()
         bottom_width = SECTION_WIDTH + len(title) + 1
-        bottom = f"{'─' * bottom_width}"
-        return f"\n{header}\n{HIGHLIGHT_DEFAULT_COLOR.decorate(content)}\n{bottom}\n"
+        bottom = HEADER_HIGHLIGHT_COLOR.decorate(f"{'─' * bottom_width}")
+        return f"\n{header}\n{CODEBLOCK_HIGHLIGHT_COLOR.decorate(content)}\n{bottom}\n"
 
     def _process_references(self, line: str) -> str:
         """Process reference section formatting.

--- a/tests/rendering/renders/test_markdown.py
+++ b/tests/rendering/renders/test_markdown.py
@@ -40,7 +40,7 @@ def test_link_rendering(markdown_renderer):
     text = "Here's a [link](https://example.com)"
     markdown_renderer.render(text)
     assert (
-        "Here's a link (\x1b[94mhttps://example.com\x1b[0m)"
+        "Here's a link (\x1b[96mhttps://example.com\x1b[0m)"
         in markdown_renderer._stream.output
     )
     assert "[link](https://example.com)" not in markdown_renderer._stream.output


### PR DESCRIPTION
This updates the coloring in MarkdownRenderer class to make the text more likely to be seen by the user and not cause any harm in the eyes.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-925](https://issues.redhat.com/browse/RSPEED-925)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
