### PR TITLE
[RSPEED-823] Fix legal message not showing up on each session

### DIFF
--- a/command_line_assistant/utils/files.py
+++ b/command_line_assistant/utils/files.py
@@ -77,10 +77,6 @@ def write_file(contents: Union[str, bytes], path: Path, mode: int = 0o600) -> No
         mode (int): The permissions of the given file. Defaults to 0600.
     """
     try:
-        if path.exists():
-            logger.debug("File %s already exists. Skipping creation.", path)
-            return
-
         logger.debug(
             "File %s does not exist. Creating it with permissions %s", path, mode
         )


### PR DESCRIPTION
The legal message was not being displayed on every session as we were not updating the file consistently.

This patch fixes it.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-823](https://issues.redhat.com/browse/RSPEED-823)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
