### PR TITLE
[RSPEED-801] Prevent --with-output without terminal capture

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -41,6 +41,7 @@ from command_line_assistant.terminal.parser import (
     find_output_by_index,
     parse_terminal_output,
 )
+from command_line_assistant.terminal.reader import TERMINAL_CAPTURE_FILE
 from command_line_assistant.utils.benchmark import TimingLogger
 from command_line_assistant.utils.cli import (
     CommandContext,
@@ -573,6 +574,13 @@ class SingleQuestionOperation(BaseChatOperation):
             )
             raise ChatCommandException(
                 "Your stdin input needs to have at least 2 characters."
+            )
+
+        # If the user tries to do "c -w 1" or "c -w 1 "help me figure this out"
+        # and there is no terminal capture log file, we just error out.
+        if self.args.with_output and not TERMINAL_CAPTURE_FILE.exists():
+            raise ChatCommandException(
+                "Adding context from terminal output is only allowed if terminal capture is active."
             )
 
     @timing.timeit

--- a/command_line_assistant/commands/shell.py
+++ b/command_line_assistant/commands/shell.py
@@ -17,7 +17,10 @@ from command_line_assistant.integrations import (
     BASH_INTERACTIVE,
 )
 from command_line_assistant.rendering.renders.text import TextRenderer
-from command_line_assistant.terminal.reader import OUTPUT_FILE_NAME, start_capturing
+from command_line_assistant.terminal.reader import (
+    TERMINAL_CAPTURE_FILE,
+    start_capturing,
+)
 from command_line_assistant.utils.cli import (
     SubParsersAction,
     create_subparser,
@@ -146,7 +149,7 @@ class EnableTerminalCapture(BaseShellOperation):
             "Starting terminal reader. Press Ctrl + D to stop the capturing."
         )
         self.text_renderer.render(
-            f"Terminal capture log is being written to {OUTPUT_FILE_NAME}"
+            f"Terminal capture log is being written to {TERMINAL_CAPTURE_FILE}"
         )
         self._initialize_bash_folder()
         start_capturing()

--- a/command_line_assistant/terminal/parser.py
+++ b/command_line_assistant/terminal/parser.py
@@ -4,7 +4,7 @@ import json
 import logging
 import re
 
-from command_line_assistant.terminal.reader import OUTPUT_FILE_NAME
+from command_line_assistant.terminal.reader import TERMINAL_CAPTURE_FILE
 
 #: The compiled regex to clean the ANSI escape sequence
 ANSI_ESCAPE_SEQ = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
@@ -22,14 +22,14 @@ def parse_terminal_output() -> list[dict[str, str]]:
     """
     result = []
 
-    if not OUTPUT_FILE_NAME.exists():
+    if not TERMINAL_CAPTURE_FILE.exists():
         logger.warning(
             "Terminal output requested but couldn't find file at %s. Returning empty list.",
-            OUTPUT_FILE_NAME,
+            TERMINAL_CAPTURE_FILE,
         )
         return result
 
-    with OUTPUT_FILE_NAME.open(mode="r") as handler:
+    with TERMINAL_CAPTURE_FILE.open(mode="r") as handler:
         for block in handler:
             # Parse the JSON
             try:

--- a/tests/commands/test_chat.py
+++ b/tests/commands/test_chat.py
@@ -669,3 +669,30 @@ def test_chat_command_with_invalid_args(default_namespace):
 
     # TODO(r0x0d): Fix this later. It should exit with 1 and give the help message.
     assert result == 0  # Command should fail
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    (
+        (
+            {"query_string": "", "stdin": "", "with_output": ""},
+            "Your query needs to have at least 2 characters. Either query or stdin are empty.",
+        ),
+        (
+            {"query_string": "a", "stdin": "", "with_output": ""},
+            "Your query needs to have at least 2 characters.",
+        ),
+        (
+            {"query_string": "", "stdin": "a", "with_output": ""},
+            "Your stdin input needs to have at least 2 characters.",
+        ),
+        (
+            {"query_string": "aa", "stdin": "", "with_output": 1},
+            "Adding context from terminal output is only allowed if terminal capture is active.",
+        ),
+    ),
+)
+def test_validate_query(args, expected, default_kwargs):
+    default_kwargs["args"] = Namespace(**args)
+    with pytest.raises(ChatCommandException, match=expected):
+        SingleQuestionOperation(**default_kwargs).execute()


### PR DESCRIPTION
If we are not in a terminal capture session, we will prevent the --with-output from working.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-801](https://issues.redhat.com/browse/RSPEED-801)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
