### PR TITLE
Add VSCode debug json for both CLA and CLAD

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    "configurations": [
+        {
+            "name": "CLA",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "command_line_assistant.initialize",
+            "console": "integratedTerminal",
+            "args": "${command:pickArgs}",
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}",
+            }
+        },
+        {
+            "name": "CLA(D)",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "command_line_assistant.daemon.clad",
+            "console": "internalConsole",
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}",
+                "XDG_CONFIG_DIRS": "${workspaceFolder}/data/development/xdg"
+            }
+        }
+    ]
+}

--- a/command_line_assistant/initialize.py
+++ b/command_line_assistant/initialize.py
@@ -81,3 +81,7 @@ def initialize() -> int:
     except KeyboardInterrupt:
         error_renderer.render("Uh, oh! Keyboard interrupt detected.")
         return 1
+
+
+if __name__ == "__main__":
+    sys.exit(initialize())


### PR DESCRIPTION
This is a minor enhancement to allow us running CLA and CLAD with debugpy.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
