### PR TITLE
[RSPEED-770] Add general file locking mechanism

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -47,7 +47,7 @@ from command_line_assistant.utils.cli import (
     CommandContext,
     SubParsersAction,
 )
-from command_line_assistant.utils.files import guess_mimetype
+from command_line_assistant.utils.files import NamedFileLock, guess_mimetype
 from command_line_assistant.utils.renderers import (
     create_error_renderer,
     create_interactive_renderer,
@@ -502,6 +502,14 @@ class InteractiveChatOperation(BaseChatOperation):
 
     def execute(self) -> None:
         """Default method to execute the operation"""
+
+        terminal_file_lock = NamedFileLock(name="terminal")
+
+        if terminal_file_lock.is_locked:
+            raise ChatCommandException(
+                "Interactive chat mode is not available while terminal capture is active."
+            )
+
         try:
             user_id = self.user_proxy.GetUserId(self.context.effective_user_id)
             chat_id = self._create_chat_session(

--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -507,7 +507,8 @@ class InteractiveChatOperation(BaseChatOperation):
 
         if terminal_file_lock.is_locked:
             raise ChatCommandException(
-                "Interactive chat mode is not available while terminal capture is active. To exit the current terminal capture session, press Ctrl + D."
+                f"Detected a terminal capture session running with pid '{terminal_file_lock.pid}'."
+                " Interactive chat mode is not available while terminal capture is active, you must stop the previous one."
             )
 
         try:

--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -507,7 +507,7 @@ class InteractiveChatOperation(BaseChatOperation):
 
         if terminal_file_lock.is_locked:
             raise ChatCommandException(
-                "Interactive chat mode is not available while terminal capture is active."
+                "Interactive chat mode is not available while terminal capture is active. To exit the current terminal capture session, press Ctrl + D."
             )
 
         try:

--- a/command_line_assistant/commands/shell.py
+++ b/command_line_assistant/commands/shell.py
@@ -149,7 +149,7 @@ class EnableTerminalCapture(BaseShellOperation):
 
         if file_lock.is_locked:
             raise ShellCommandException(
-                "Another instance of terminal capture is already running."
+                "Terminal capture is already enabled. Press Ctrl + D to stop capturing."
             )
 
         with file_lock:

--- a/command_line_assistant/commands/shell.py
+++ b/command_line_assistant/commands/shell.py
@@ -149,7 +149,8 @@ class EnableTerminalCapture(BaseShellOperation):
 
         if file_lock.is_locked:
             raise ShellCommandException(
-                "Terminal capture is already enabled. Press Ctrl + D to stop capturing."
+                f"Detected a terminal capture session running with pid '{file_lock.pid}'."
+                " In order to start a new terminal capture session, you must stop the previous one."
             )
 
         with file_lock:
@@ -185,7 +186,7 @@ class ShellCommand(BaseCLICommand):
             return 0
         except ShellCommandException as e:
             logger.info("Failed to execute shell command: %s", str(e))
-            error_renderer.render(f"Failed to execute shell command: {str(e)}")
+            error_renderer.render(str(e))
             return 1
 
 
@@ -209,7 +210,11 @@ def register_subcommand(parser: SubParsersAction):
     interactive_mode.add_argument(
         "--enable-interactive",
         action="store_true",
-        help="Enable the shell integration for interactive mode on the system. Currently, only BASH is supported. After the interactive was sourced, hit Ctrl + G in your terminal to enable interactive mode.",
+        help=(
+            "Enable the shell integration for interactive mode on the system. "
+            "Currently, only BASH is supported. After the interactive was "
+            "sourced, hit Ctrl + G in your terminal to enable interactive mode."
+        ),
     )
     interactive_mode.add_argument(
         "--disable-interactive",

--- a/command_line_assistant/utils/files.py
+++ b/command_line_assistant/utils/files.py
@@ -109,7 +109,7 @@ class NamedFileLock:
     using a lock file. The lock file contains the PID of the capturing process.
 
     Usage:
-        with NamedFileLock() as lock:
+        with NamedFileLock(name="my_file") as lock:
             # Execute your operations
         # Lock is automatically released
     """
@@ -117,8 +117,9 @@ class NamedFileLock:
     def __init__(self, name: str):
         """Initialize the named file lock mechanism."""
         self._pid = os.getpid()
-        self._name = name
+        self._name = name.replace("-", "_")
         self._lock_file = Path(get_xdg_state_path(), name + ".lock")
+
 
     @property
     def is_locked(self) -> bool:
@@ -134,7 +135,7 @@ class NamedFileLock:
 
         try:
             pid = int(self._lock_file.read_text().strip())
-            # Check if process is still running
+            # Check if process is still running 
             os.kill(pid, 0)
             return True
         except (ValueError, OSError, FileNotFoundError):

--- a/command_line_assistant/utils/files.py
+++ b/command_line_assistant/utils/files.py
@@ -1,10 +1,17 @@
 """Utilitary module to handle file operations"""
 
+import errno
+import fcntl
 import logging
 import mimetypes
+import os
+import stat
+import tempfile
 from io import TextIOWrapper
 from pathlib import Path
 from typing import Optional, Union
+
+from command_line_assistant.utils.environment import get_xdg_state_path
 
 logger = logging.getLogger(__name__)
 
@@ -93,3 +100,94 @@ def write_file(contents: Union[str, bytes], path: Path, mode: int = 0o600) -> No
             path,
             str(e),
         )
+
+
+class NamedFileLock:
+    """File-based lock mechanism for general locking purposes.
+
+    This class provides a way to track state across processes
+    using a lock file. The lock file contains the PID of the capturing process.
+
+    Usage:
+        with NamedFileLock() as lock:
+            # Execute your operations
+        # Lock is automatically released
+    """
+
+    def __init__(self, name: str = "lock"):
+        """Initialize the named file lock mechanism."""
+        self._pid = os.getpid()
+        self._name = name
+        self._lock_file = Path(get_xdg_state_path(), name + ".pid")
+
+    @property
+    def is_locked(self) -> bool:
+        """Check if a lock is currently active.
+
+        This checks if the lock file exists and if the PID in it is still running.
+
+        Returns:
+            bool: True if a lock is active, False otherwise
+        """
+        if not self._lock_file.exists():
+            return False
+
+        try:
+            pid = int(self._lock_file.read_text().strip())
+            # Check if process is still running
+            os.kill(pid, 0)
+            return True
+        except (ValueError, OSError, FileNotFoundError):
+            # Clean up stale lock file
+            self._lock_file.unlink(missing_ok=True)
+            return False
+
+    def acquire(self) -> None:
+        """Acquire the lock.
+
+        Raises:
+            RuntimeError: If a lock is already active
+        """
+        if self.is_locked:
+            raise RuntimeError(
+                "A lock is already active in another process. "
+                "Please, remove the lock before trying to acquire again."
+            )
+
+        create_folder(self._lock_file.parent, parents=True)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".pid", prefix=self._name, dir=self._lock_file.parent
+        ) as handler:
+            # Write current process ID
+            handler.write(str(os.getpid()))
+            handler.flush()
+
+            # stat.S_IRUSR = Owner has read permission
+            # stat.S_IWUSR = Owner has write permission
+            os.chmod(handler.name, stat.S_IRUSR | stat.S_IWUSR)
+            # Use fcntl for file locking
+            fcntl.flock(handler.file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+            try:
+                os.link(handler.name, self._lock_file)
+            except FileExistsError as e:
+                if e.errno != errno.EEXIST:
+                    raise
+
+    def release(self) -> None:
+        """Release the terminal lock."""
+        self._lock_file.unlink(missing_ok=True)
+
+    def __enter__(self) -> "NamedFileLock":
+        """Context manager entry.
+
+        Returns:
+            NamedFileLock: Instance of itself
+        """
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Context manager exit."""
+        self.release()

--- a/command_line_assistant/utils/files.py
+++ b/command_line_assistant/utils/files.py
@@ -114,11 +114,21 @@ class NamedFileLock:
         # Lock is automatically released
     """
 
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         """Initialize the named file lock mechanism."""
-        self._pid = os.getpid()
-        self._name = name.replace("-", "_")
-        self._lock_file = Path(get_xdg_state_path(), name + ".lock")
+        self._pid: int = os.getpid()
+        self._name: str = name.replace("-", "_")
+        self._lock_file: Path = Path(get_xdg_state_path(), name + ".lock")
+
+    @property
+    def pid(self) -> int:
+        """Return the parent pid."""
+        return self._pid
+
+    @pid.setter
+    def pid(self, value: int) -> None:
+        """Set the value for the internal _pid property."""
+        self._pid = value
 
     @property
     def is_locked(self) -> bool:

--- a/command_line_assistant/utils/files.py
+++ b/command_line_assistant/utils/files.py
@@ -120,7 +120,6 @@ class NamedFileLock:
         self._name = name.replace("-", "_")
         self._lock_file = Path(get_xdg_state_path(), name + ".lock")
 
-
     @property
     def is_locked(self) -> bool:
         """Check if a lock is currently active.
@@ -135,7 +134,8 @@ class NamedFileLock:
 
         try:
             pid = int(self._lock_file.read_text().strip())
-            # Check if process is still running 
+            # Check if process is still running. Sending signal 0 to a process
+            # will raise an OSError if no process with that pid is running.
             os.kill(pid, 0)
             return True
         except (ValueError, OSError, FileNotFoundError):

--- a/command_line_assistant/utils/files.py
+++ b/command_line_assistant/utils/files.py
@@ -114,11 +114,11 @@ class NamedFileLock:
         # Lock is automatically released
     """
 
-    def __init__(self, name: str = "lock"):
+    def __init__(self, name: str):
         """Initialize the named file lock mechanism."""
         self._pid = os.getpid()
         self._name = name
-        self._lock_file = Path(get_xdg_state_path(), name + ".pid")
+        self._lock_file = Path(get_xdg_state_path(), name + ".lock")
 
     @property
     def is_locked(self) -> bool:

--- a/tests/commands/test_chat.py
+++ b/tests/commands/test_chat.py
@@ -24,6 +24,7 @@ from command_line_assistant.dbus.exceptions import (
 )
 from command_line_assistant.dbus.structures.chat import ChatEntry, ChatList, Response
 from command_line_assistant.exceptions import ChatCommandException, StopInteractiveMode
+from command_line_assistant.utils.files import NamedFileLock
 from command_line_assistant.utils.renderers import (
     create_error_renderer,
     create_text_renderer,
@@ -421,6 +422,20 @@ def test_interactive_mode_empty_question(default_namespace, default_kwargs, caps
 
         captured = capsys.readouterr()
         assert "Your question can't be empty" in captured.err
+
+
+def test_interactive_chat_while_in_terminal_capture(default_namespace, default_kwargs):
+    default_kwargs["args"] = default_namespace
+    default_kwargs["error_renderer"] = create_error_renderer()
+    with (
+        NamedFileLock(name="terminal"),
+        pytest.raises(
+            ChatCommandException,
+            match="Interactive chat mode is not available while terminal capture is active.",
+        ),
+    ):
+        interactive_operation = InteractiveChatOperation(**default_kwargs)
+        interactive_operation.execute()
 
 
 @pytest.mark.parametrize(

--- a/tests/commands/test_shell.py
+++ b/tests/commands/test_shell.py
@@ -1,3 +1,4 @@
+import re
 from argparse import ArgumentParser, Namespace
 from unittest import mock
 
@@ -203,7 +204,9 @@ def test_enable_terminal_capture_twice(monkeypatch, default_kwargs):
         NamedFileLock(name="terminal"),
         pytest.raises(
             ShellCommandException,
-            match="Another instance of terminal capture is already running.",
+            match=re.escape(
+                "Terminal capture is already enabled. Press Ctrl + D to stop capturing."
+            ),
         ),
     ):
         EnableTerminalCapture(**default_kwargs).execute()

--- a/tests/commands/test_shell.py
+++ b/tests/commands/test_shell.py
@@ -1,4 +1,3 @@
-import re
 from argparse import ArgumentParser, Namespace
 from unittest import mock
 
@@ -204,9 +203,7 @@ def test_enable_terminal_capture_twice(monkeypatch, default_kwargs):
         NamedFileLock(name="terminal"),
         pytest.raises(
             ShellCommandException,
-            match=re.escape(
-                "Terminal capture is already enabled. Press Ctrl + D to stop capturing."
-            ),
+            match="Detected a terminal capture session running with pid",
         ),
     ):
         EnableTerminalCapture(**default_kwargs).execute()

--- a/tests/commands/test_shell.py
+++ b/tests/commands/test_shell.py
@@ -14,6 +14,7 @@ from command_line_assistant.commands.shell import (
     register_subcommand,
 )
 from command_line_assistant.exceptions import ShellCommandException
+from command_line_assistant.utils.files import NamedFileLock
 from command_line_assistant.utils.renderers import create_text_renderer
 
 
@@ -193,6 +194,19 @@ def test_enable_terminal_capture(monkeypatch, default_kwargs, capsys):
         "Starting terminal reader. Press Ctrl + D to stop the capturing."
         in captured.out
     )
+
+
+def test_enable_terminal_capture_twice(monkeypatch, default_kwargs):
+    default_kwargs["text_renderer"] = create_text_renderer()
+    monkeypatch.setattr(shell, "start_capturing", mock.Mock())
+    with (
+        NamedFileLock(name="terminal"),
+        pytest.raises(
+            ShellCommandException,
+            match="Another instance of terminal capture is already running.",
+        ),
+    ):
+        EnableTerminalCapture(**default_kwargs).execute()
 
 
 def test_enable_terminal_capture_execution(default_kwargs, monkeypatch):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from command_line_assistant.config.schemas.logging import LoggingSchema
 from command_line_assistant.dbus import constants as dbus_constants
 from command_line_assistant.dbus.context import DaemonContext
 from command_line_assistant.logger import LOGGING_CONFIG_DICTIONARY
+from command_line_assistant.utils import files
 from command_line_assistant.utils.cli import CommandContext
 from command_line_assistant.utils.renderers import (
     create_error_renderer,
@@ -21,6 +22,12 @@ from command_line_assistant.utils.renderers import (
     create_warning_renderer,
 )
 from tests.helpers import MockStream
+
+
+@pytest.fixture(autouse=True)
+def mock_xdg_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(files, "get_xdg_state_path", lambda: tmp_path)
+    return tmp_path
 
 
 @pytest.fixture

--- a/tests/utils/test_files.py
+++ b/tests/utils/test_files.py
@@ -109,14 +109,14 @@ class TestNamedFileLock:
         lock.acquire()
 
         expected_pid = os.getpid()
-        expected_path = Path(mock_xdg_path, "test.pid")
+        expected_path = Path(mock_xdg_path, "test.lock")
         assert os.path.exists(expected_path)
         assert int(expected_path.read_text()) == expected_pid
 
     def test_acquire_as_context_manager(self, mock_xdg_path):
         with NamedFileLock(name="test"):
             expected_pid = os.getpid()
-            expected_path = Path(mock_xdg_path, "test.pid")
+            expected_path = Path(mock_xdg_path, "test.lock")
             assert os.path.exists(expected_path)
             assert int(expected_path.read_text()) == expected_pid
 
@@ -135,7 +135,7 @@ class TestNamedFileLock:
         assert len(os.listdir(mock_xdg_path)) == len(lock_names)
 
         for lock_name in lock_names:
-            expected_path = Path(mock_xdg_path, f"{lock_name}.pid")
+            expected_path = Path(mock_xdg_path, f"{lock_name}.lock")
             assert os.path.exists(expected_path)
             assert int(expected_path.read_text()) == expected_pid
 
@@ -144,7 +144,7 @@ class TestNamedFileLock:
         lock.acquire()
 
         expected_pid = os.getpid()
-        expected_path = Path(mock_xdg_path, "test.pid")
+        expected_path = Path(mock_xdg_path, "test.lock")
         assert os.path.exists(expected_path)
         assert int(expected_path.read_text()) == expected_pid
 
@@ -159,7 +159,7 @@ class TestNamedFileLock:
         lock = NamedFileLock(name="test")
         lock.acquire()
 
-        expected_path = Path(mock_xdg_path, "test.pid")
+        expected_path = Path(mock_xdg_path, "test.lock")
         assert os.path.exists(expected_path)
         assert lock.is_locked
 
@@ -173,7 +173,7 @@ class TestNamedFileLock:
         lock = NamedFileLock(name="test")
         lock.acquire()
 
-        expected_path = Path(mock_xdg_path, "test.pid")
+        expected_path = Path(mock_xdg_path, "test.lock")
         assert not lock.is_locked
         assert not os.path.exists(expected_path)
 
@@ -182,5 +182,5 @@ class TestNamedFileLock:
         lock.acquire()
         lock.release()
 
-        expected_path = Path(mock_xdg_path, "test.pid")
+        expected_path = Path(mock_xdg_path, "test.lock")
         assert not os.path.exists(expected_path)

--- a/tests/utils/test_files.py
+++ b/tests/utils/test_files.py
@@ -1,8 +1,15 @@
+import os
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
-from command_line_assistant.utils.files import create_folder, guess_mimetype, write_file
+from command_line_assistant.utils.files import (
+    NamedFileLock,
+    create_folder,
+    guess_mimetype,
+    write_file,
+)
 
 
 def test_guess_mimetype():
@@ -94,3 +101,86 @@ def test_write_file_permission_error(tmp_path, monkeypatch):
     # Should log error and continue without raising exception
     with pytest.raises(PermissionError):
         write_file("test content", test_file)
+
+
+class TestNamedFileLock:
+    def test_acquire(self, mock_xdg_path):
+        lock = NamedFileLock(name="test")
+        lock.acquire()
+
+        expected_pid = os.getpid()
+        expected_path = Path(mock_xdg_path, "test.pid")
+        assert os.path.exists(expected_path)
+        assert int(expected_path.read_text()) == expected_pid
+
+    def test_acquire_as_context_manager(self, mock_xdg_path):
+        with NamedFileLock(name="test"):
+            expected_pid = os.getpid()
+            expected_path = Path(mock_xdg_path, "test.pid")
+            assert os.path.exists(expected_path)
+            assert int(expected_path.read_text()) == expected_pid
+
+        # After we leave the context manager, the file should be gone.
+        assert not os.path.exists(expected_path)
+
+    def test_acquire_multiple_locks(self, mock_xdg_path):
+        lock_names = ["test", "terminal", "files", "star-trek"]
+
+        for lock_name in lock_names:
+            lock = NamedFileLock(name=lock_name)
+            lock.acquire()
+
+        expected_pid = os.getpid()
+
+        assert len(os.listdir(mock_xdg_path)) == len(lock_names)
+
+        for lock_name in lock_names:
+            expected_path = Path(mock_xdg_path, f"{lock_name}.pid")
+            assert os.path.exists(expected_path)
+            assert int(expected_path.read_text()) == expected_pid
+
+    def test_acquire_twice_same_lock(self, mock_xdg_path):
+        lock = NamedFileLock(name="test")
+        lock.acquire()
+
+        expected_pid = os.getpid()
+        expected_path = Path(mock_xdg_path, "test.pid")
+        assert os.path.exists(expected_path)
+        assert int(expected_path.read_text()) == expected_pid
+
+        with pytest.raises(
+            RuntimeError,
+            match="A lock is already active in another process. "
+            "Please, remove the lock before trying to acquire again.",
+        ):
+            lock.acquire()
+
+    def test_is_locked_success(self, mock_xdg_path):
+        lock = NamedFileLock(name="test")
+        lock.acquire()
+
+        expected_path = Path(mock_xdg_path, "test.pid")
+        assert os.path.exists(expected_path)
+        assert lock.is_locked
+
+    def test_is_locked_file_not_exist(self):
+        lock = NamedFileLock(name="test")
+        assert not lock.is_locked
+
+    def test_is_locked_exception(self, mock_xdg_path, monkeypatch):
+        monkeypatch.setattr(os, "kill", mock.Mock(side_effect=ValueError("oh no.")))
+
+        lock = NamedFileLock(name="test")
+        lock.acquire()
+
+        expected_path = Path(mock_xdg_path, "test.pid")
+        assert not lock.is_locked
+        assert not os.path.exists(expected_path)
+
+    def test_release_lock(self, mock_xdg_path):
+        lock = NamedFileLock(name="test")
+        lock.acquire()
+        lock.release()
+
+        expected_path = Path(mock_xdg_path, "test.pid")
+        assert not os.path.exists(expected_path)


### PR DESCRIPTION
This locking mechanism is intended to be used alongside the terminal capture feature from `shell --enable-capture`.

This generic file locking mechanism aims to do the following:
- Create a lock file with a given name
- Lock the file so no users can edit
- Allow only the $USER to read/write to it

The class can also be used as a contextmanager or regulary accessing its methods `acquire` and `release`.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-770](https://issues.redhat.com/browse/RSPEED-770)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
