### PR TITLE
Add missing property and config to launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,5 +1,13 @@
 {
+    "version": "0.2.0",
     "configurations": [
+        {
+            "name": "Python Debugger: Current File",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        },
         {
             "name": "CLA",
             "type": "debugpy",
@@ -21,6 +29,6 @@
                 "PYTHONPATH": "${workspaceFolder}",
                 "XDG_CONFIG_DIRS": "${workspaceFolder}/data/development/xdg"
             }
-        }
+        },
     ]
 }


### PR DESCRIPTION
We were missing a property in our launch.json, and due to that, we couldn't execute tests in debug mode.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
