### PR TITLE
[RSPEED-898] Generate tarball on every tag release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   generate:
-    name: Generate cross-platform builds
+    name: Generate  builds
     runs-on: ubuntu-latest
     steps:
       - uses: olegtarasov/get-tag@v2.1
@@ -22,14 +22,17 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.21'
+      - name: Install dependencies
+        run: |
+          # TODO(r0x0d): Refactor this https://issues.redhat.com/browse/RSPEED-339
+          sudo apt update -y
+          sudo apt install libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-4.0 -y
+          make install
 
       - name: Generate distribution tarball
         run: |
-          mkdir dist && make distribution-tarball
-          sudo mv *.tar.gz dist/
+          VENV_PATH=$(poetry env info --path)
+          make distribution-tarball SPHINXBUILD=$VENV_PATH/bin/sphinx-build
         env:
           VERSION: '${{ steps.tagName.outputs.tag }}'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Generate release-artifacts
+
+on:
+  push:
+    tags:
+        - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    name: Generate cross-platform builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: olegtarasov/get-tag@v2.1
+        id: tagName
+        with:
+          tagRegex: "v(.*)"  # Optional. Returns specified group text as tag name. Full tag string is returned if regex is not defined.
+          tagRegexGroup: 1 # Optional. Default is 1.
+
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Generate distribution tarball
+        run: |
+          mkdir dist && make distribution-tarball
+          sudo mv *.tar.gz dist/
+        env:
+          VERSION: '${{ steps.tagName.outputs.tag }}'
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/*
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true

--- a/Makefile
+++ b/Makefile
@@ -81,11 +81,11 @@ clean: ## Clean project files
 	   command_line_assistant.egg-info \
 	   .ruff_cache \
 	   .coverage \
-	   dist \
 	   .tox \
 	   junit.xml \
 	   coverage.xml \
 	   .mypy_cache \
+	   dist \
 	   $(PKGNAME)-$(VERSION).tar.gz
 	$(MAKE) -C docs clean
 	$(MAKE) -C data/release/selinux
@@ -126,6 +126,7 @@ html-docs: ## Build html docs
 	$(MAKE) -C docs html
 
 distribution-tarball: clean ## Generate distribution tarball
+	mkdir dist 
 	tar --create \
 		--gzip \
 		--file /tmp/$(PKGNAME)-$(VERSION).tar.gz \
@@ -151,8 +152,9 @@ distribution-tarball: clean ## Generate distribution tarball
 		--exclude=.packit.yaml \
 		--exclude=sonar-project.properties \
 		--exclude=poetry.toml \
+		--exclude=dist \
 		--transform s/^\./$(PKGNAME)-$(VERSION)/ \
-		. && mv /tmp/$(PKGNAME)-$(VERSION).tar.gz .
+		. && mv /tmp/$(PKGNAME)-$(VERSION).tar.gz dist
 
 release: ## Interactively bump the version (major, minor, or patch)
 	@echo "Current version: $(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ clean: ## Clean project files
 	   .tox \
 	   junit.xml \
 	   coverage.xml \
+	   .mypy_cache \
 	   $(PKGNAME)-$(VERSION).tar.gz
 	$(MAKE) -C docs clean
 	$(MAKE) -C data/release/selinux
@@ -139,7 +140,17 @@ distribution-tarball: clean ## Generate distribution tarball
 		--exclude=scripts \
 		--exclude=docs \
 		--exclude=tests \
-		--exclude=.roproject \
+		--exclude=.ropeproject \
+		--exclude=.gitlab-ci.yml \
+		--exclude=.readthedocs.yaml \
+		--exclude=podman-compose.yaml \
+		--exclude=schemas \
+		--exclude=tox.ini \
+		--exclude=renovate.json \
+		--exclude=.pre-commit-config.yaml \
+		--exclude=.packit.yaml \
+		--exclude=sonar-project.properties \
+		--exclude=poetry.toml \
 		--transform s/^\./$(PKGNAME)-$(VERSION)/ \
 		. && mv /tmp/$(PKGNAME)-$(VERSION).tar.gz .
 

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ html-docs: ## Build html docs
 	$(MAKE) -C docs html
 
 distribution-tarball: clean ## Generate distribution tarball
-	mkdir dist 
+	mkdir dist
 	tar --create \
 		--gzip \
 		--file /tmp/$(PKGNAME)-$(VERSION).tar.gz \

--- a/packaging/command-line-assistant.spec
+++ b/packaging/command-line-assistant.spec
@@ -16,7 +16,7 @@ Summary:        A simple wrapper to interact with RAG
 
 License:        Apache-2.0
 URL:            https://github.com/rhel-lightspeed/command-line-assistant
-Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+Source0:        %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 # noarch because there is no extension module for this package.
 BuildArch:      noarch
 


### PR DESCRIPTION
This will create a custom tarball with only the necessary items for our release. No more development/project specific will be included in the tarball.

The github ones will still be there, but ours will be refined.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-898](https://issues.redhat.com/browse/RSPEED-898)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
