### PR TITLE
Point the test job to the `develop` branch

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -70,7 +70,7 @@ jobs:
     identifier: level1-tests
     trigger: pull_request
     fmf_url: "https://gitlab.cee.redhat.com/rhel-lightspeed/enhanced-shell/cla-tests"
-    fmf_ref: "main"
+    fmf_ref: "develop"
     tmt_plan: "level1"
     use_internal_tf: True
     targets:


### PR DESCRIPTION
* We have decided to branch our test suite to have more flexibility when reacting to the upstream changes
* main branch hosts tests for downstream/compose builds
* develop branch is shifted left to address potential changes to the upstream codebase, aiming to always green suite for both upstream and downstream

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
