### PR TITLE
Revert type annotations for SQLAlchemy

### DIFF
--- a/command_line_assistant/daemon/database/models/base.py
+++ b/command_line_assistant/daemon/database/models/base.py
@@ -3,11 +3,10 @@
 import uuid
 from typing import Any
 
-from sqlalchemy import DateTime, func
+from sqlalchemy import Column, DateTime, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql.type_api import TypeEngine
 from sqlalchemy.types import CHAR, TypeDecorator
 
@@ -102,14 +101,10 @@ class BaseMixin:
 
     __name__ = "BaseMixin"
 
-    id: Mapped[GUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
-    created_at: Mapped[DateTime] = mapped_column(
-        DateTime, server_default=func.now(), nullable=False
-    )
-    updated_at: Mapped[DateTime] = mapped_column(
-        DateTime, server_default=func.now(), nullable=False
-    )
-    deleted_at: Mapped[DateTime] = mapped_column(DateTime, default=None, nullable=True)
+    id = Column(GUID(), primary_key=True, default=uuid.uuid4)  # type: ignore[var-annotated]
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)  # type: ignore[var-annotated]
+    updated_at = Column(DateTime, server_default=func.now(), nullable=False)  # type: ignore[var-annotated]
+    deleted_at = Column(DateTime, default=None, nullable=True)  # type: ignore[var-annotated]
 
 
 #: The declarative base model for SQLAlchemy models

--- a/command_line_assistant/daemon/database/models/chat.py
+++ b/command_line_assistant/daemon/database/models/chat.py
@@ -1,7 +1,6 @@
 """Module containing SQLAlchemy models for the chat session."""
 
-from sqlalchemy import String, Text
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import Column, String, Text
 
 from command_line_assistant.daemon.database.models.base import GUID, BaseModel
 
@@ -11,6 +10,6 @@ class ChatModel(BaseModel):
 
     __tablename__ = "chat"
 
-    user_id: Mapped[GUID] = mapped_column(GUID(), nullable=False)
-    name: Mapped[int] = mapped_column(String(25), nullable=False)
-    description: Mapped[Text] = mapped_column(Text, nullable=True)
+    user_id = Column(GUID(), nullable=False)  # type: ignore[var-annotated]
+    name = Column(String(25), nullable=False)  # type: ignore[var-annotated]
+    description = Column(Text, nullable=True)  # type: ignore[var-annotated]

--- a/command_line_assistant/daemon/database/models/history.py
+++ b/command_line_assistant/daemon/database/models/history.py
@@ -1,7 +1,7 @@
 """Module containing SQLAlchemy models for the history."""
 
-from sqlalchemy import ForeignKey, Text
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy import Column, ForeignKey, Text
+from sqlalchemy.orm import relationship
 
 from command_line_assistant.daemon.database.models.base import GUID, BaseModel
 
@@ -11,8 +11,8 @@ class HistoryModel(BaseModel):
 
     __tablename__ = "history"
 
-    user_id: Mapped[GUID] = mapped_column(GUID(), nullable=False)
-    chat_id: Mapped[GUID] = mapped_column(GUID(), ForeignKey("chat.id"), nullable=False)
+    user_id = Column(GUID(), nullable=False)  # type: ignore[var-annotated]
+    chat_id = Column(GUID(), ForeignKey("chat.id"), nullable=False)  # type: ignore[var-annotated]
 
     interactions = relationship("InteractionModel", lazy="subquery", backref="history")
     chats = relationship("ChatModel", lazy="subquery", backref="history")
@@ -23,8 +23,6 @@ class InteractionModel(BaseModel):
 
     __tablename__ = "interaction"
 
-    history_id: Mapped[GUID] = mapped_column(
-        GUID(), ForeignKey("history.id"), nullable=False
-    )
-    question: Mapped[Text] = mapped_column(Text, nullable=False)
-    response: Mapped[Text] = mapped_column(Text, nullable=False)
+    history_id = Column(GUID(), ForeignKey("history.id"), nullable=False)  # type: ignore[var-annotated]
+    question = Column(Text, nullable=False)  # type: ignore[var-annotated]
+    response = Column(Text, nullable=False)  # type: ignore[var-annotated]


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->
SQLAlchemy 2.x has better support for it, but since we also support version 1.4.x, there is not much support for type annotations there.

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
