### PR TITLE
[RSPEED-991] Submit systeminfo to backend as part of context

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import platform
 from argparse import Namespace
 from enum import auto
 from io import TextIOWrapper
@@ -26,6 +27,7 @@ from command_line_assistant.dbus.structures.chat import (
     Question,
     Response,
     StdinInput,
+    SystemInfo,
     TerminalInput,
 )
 from command_line_assistant.exceptions import ChatCommandException, StopInteractiveMode
@@ -413,6 +415,12 @@ class BaseChatOperation(BaseOperation):
                 contents=attachment, mimetype=attachment_mimetype
             ),
             terminal=TerminalInput(output=last_output),
+            systeminfo=SystemInfo(
+                os=self.context.os_release["name"],
+                version=self.context.os_release["version_id"],
+                arch=platform.machine(),
+                id=self.context.os_release["id"],
+            ),
         )
         response = self.chat_proxy.AskQuestion(
             user_id,

--- a/command_line_assistant/dbus/interfaces/chat.py
+++ b/command_line_assistant/dbus/interfaces/chat.py
@@ -215,6 +215,7 @@ class ChatInterface(InterfaceTemplate):
             Structure: The message output in format of a d-bus structure.
         """
         content = Question.from_structure(message_input)
+
         # Submit query to backend
         data = {
             "question": content.message,
@@ -223,6 +224,13 @@ class ChatInterface(InterfaceTemplate):
                 "attachments": {
                     "contents": content.attachment.contents,
                     "mimetype": content.attachment.mimetype,
+                },
+                "terminal": content.terminal.output,
+                "systeminfo": {
+                    "os": content.systeminfo.os,
+                    "version": content.systeminfo.version,
+                    "arch": content.systeminfo.arch,
+                    "id": content.systeminfo.id,
                 },
             },
         }

--- a/command_line_assistant/dbus/structures/chat.py
+++ b/command_line_assistant/dbus/structures/chat.py
@@ -266,7 +266,7 @@ class TerminalInput(BaseDataMixin, DBusData):
         """Constructor of the class
 
         Arguments:
-            output (Str): Ouptut fromm terminal if any
+            output (Str): Output from terminal, if any
         """
         self._output: Str = output
 

--- a/command_line_assistant/dbus/structures/chat.py
+++ b/command_line_assistant/dbus/structures/chat.py
@@ -266,7 +266,7 @@ class TerminalInput(BaseDataMixin, DBusData):
         """Constructor of the class
 
         Arguments:
-            _output (Str): Ouptut fromm terminal if any
+            output (Str): Ouptut fromm terminal if any
         """
         self._output: Str = output
 
@@ -289,6 +289,98 @@ class TerminalInput(BaseDataMixin, DBusData):
         self._output = value
 
 
+class SystemInfo(BaseDataMixin, DBusData):
+    """Represents system information"""
+
+    def __init__(
+        self, os: Str = "", version: Str = "", arch: Str = "", id: Str = ""
+    ) -> None:
+        """Constructor of the class
+
+        Arguments:
+            os (Str): The operating system
+            version (Str): The version of the operating system
+            arch (Str): The architecture of the operating system
+            id (Str): The unique identifier of the operating system
+        """
+        self._os = os
+        self._version = version
+        self._arch = arch
+        self._id = id
+
+    @property
+    def os(self) -> Str:
+        """Property for internal os attribute.
+
+        Returns:
+            Str: Value of os
+        """
+        return self._os
+
+    @os.setter
+    def os(self, value: Str) -> None:
+        """Set a new os
+
+        Arguments:
+            value (Str): Value to be set to the internal property
+        """
+        self._os = value
+
+    @property
+    def version(self) -> Str:
+        """Property for internal version attribute.
+
+        Returns:
+            Str: Value of version
+        """
+        return self._version
+
+    @version.setter
+    def version(self, value: Str) -> None:
+        """Set a new version
+
+        Arguments:
+            value (Str): Value to be set to the internal property
+        """
+        self._version = value
+
+    @property
+    def arch(self) -> Str:
+        """Property for internal arch attribute.
+
+        Returns:
+            Str: Value of arch
+        """
+        return self._arch
+
+    @arch.setter
+    def arch(self, value: Str) -> None:
+        """Set a new arch
+
+        Arguments:
+            value (Str): Value to be set to the internal property
+        """
+        self._arch = value
+
+    @property
+    def id(self) -> Str:
+        """Property for internal id attribute.
+
+        Returns:
+            Str: Value of id
+        """
+        return self._id
+
+    @id.setter
+    def id(self, value: Str) -> None:
+        """Set a new id
+
+        Arguments:
+            value (Str): Value to be set to the internal property
+        """
+        self._id = value
+
+
 class Question(BaseDataMixin, DBusData):
     """Represents the input message to be sent to the backend"""
 
@@ -298,6 +390,7 @@ class Question(BaseDataMixin, DBusData):
         stdin: Optional[StdinInput] = None,
         attachment: Optional[AttachmentInput] = None,
         terminal: Optional[TerminalInput] = None,
+        systeminfo: Optional[SystemInfo] = None,
     ) -> None:
         """Constructor of the class.
 
@@ -306,11 +399,13 @@ class Question(BaseDataMixin, DBusData):
             stdin (Optional[StdinInput], optional): The stdin object if any
             attachment (Optional[AttachmentInput], optional): The attachment input if any
             terminal (Optional[TerminalInput], optional): The terminal input if any
+            systeminfo (Optional[SystemInfo], optional): The system info if any
         """
         self._message: Str = message
         self._stdin: StdinInput = stdin or StdinInput()
         self._attachment: AttachmentInput = attachment or AttachmentInput()
         self._terminal: TerminalInput = terminal or TerminalInput()
+        self._systeminfo: SystemInfo = systeminfo or SystemInfo()
 
         super().__init__()
 
@@ -385,6 +480,24 @@ class Question(BaseDataMixin, DBusData):
             value (Str): Value to be set to the internal property
         """
         self._terminal = value
+
+    @property
+    def systeminfo(self) -> SystemInfo:
+        """Property for internal systeminfo attribute.
+
+        Returns:
+            Str: Value of systeminfo
+        """
+        return self._systeminfo
+
+    @systeminfo.setter
+    def systeminfo(self, value: SystemInfo) -> None:
+        """Set a new systeminfo
+
+        Arguments:
+            value (Str): Value to be set to the internal property
+        """
+        self._systeminfo = value
 
 
 class Response(BaseDataMixin, DBusData):

--- a/tests/dbus/interfaces/test_chat.py
+++ b/tests/dbus/interfaces/test_chat.py
@@ -48,6 +48,8 @@ def test_chat_interface_ask_question(chat_interface, mock_config):
                 "context": {
                     "stdin": "",
                     "attachments": {"contents": "", "mimetype": ""},
+                    "terminal": "",
+                    "systeminfo": {"os": "", "arch": "", "id": "", "version": ""},
                 },
             },
             mock_config,


### PR DESCRIPTION
This patch introduces a couple new models to submit them to the backend to provide more refined context about the user system.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-991](https://issues.redhat.com/browse/RSPEED-991)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
