### PR TITLE
[RSPEED-1118] Default to --all in history command

### DIFF
--- a/command_line_assistant/commands/history.py
+++ b/command_line_assistant/commands/history.py
@@ -418,4 +418,7 @@ def _command_factory(args: Namespace) -> HistoryCommand:
     Returns:
         HistoryCommand: Return an instance of class
     """
+    if not (args.last or args.first or args.filter):
+        args.all = True
+
     return HistoryCommand(args)

--- a/tests/commands/test_history.py
+++ b/tests/commands/test_history.py
@@ -270,10 +270,24 @@ def test_history_empty_response(mock_dbus_service, capsys):
         ),
         (
             False,
+            True,
+            False,
+            "",
+            False,
+        ),
+        (
+            False,
             False,
             False,
             "test",
             False,
+        ),
+        (
+            False,
+            False,
+            False,
+            "test",
+            True,
         ),
     ),
 )


### PR DESCRIPTION
In case nothing is supplied when the user type `c history`, we will be defaulting it to trigger the `--all` flag.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues: [RSPEED-1118](https://issues.redhat.com/browse/RSPEED-1118)

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
