### PR TITLE
[RSPEED-1150] Fix unprocessable entity request for inference

### DIFF
--- a/command_line_assistant/dbus/interfaces/chat.py
+++ b/command_line_assistant/dbus/interfaces/chat.py
@@ -225,7 +225,7 @@ class ChatInterface(InterfaceTemplate):
                     "contents": content.attachment.contents,
                     "mimetype": content.attachment.mimetype,
                 },
-                "terminal": content.terminal.output,
+                "terminal": {"output": content.terminal.output},
                 "systeminfo": {
                     "os": content.systeminfo.os,
                     "version": content.systeminfo.version,

--- a/tests/dbus/interfaces/test_chat.py
+++ b/tests/dbus/interfaces/test_chat.py
@@ -48,7 +48,7 @@ def test_chat_interface_ask_question(chat_interface, mock_config):
                 "context": {
                     "stdin": "",
                     "attachments": {"contents": "", "mimetype": ""},
-                    "terminal": "",
+                    "terminal": {"output": ""},
                     "systeminfo": {"os": "", "arch": "", "id": "", "version": ""},
                 },
             },


### PR DESCRIPTION
We were passing the wrong format to the backend with the terminal context. That was causing the API to reject our request with a 403.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-1150](https://issues.redhat.com/browse/RSPEED-1150)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
