### PR TITLE
[RSPEED-1073] Limit permission for history database to own user

### DIFF
--- a/tests/config/schemas/test_database.py
+++ b/tests/config/schemas/test_database.py
@@ -102,7 +102,9 @@ def test_database_connection_string_path_expansion():
 def test_database_get_connection_url():
     """Test database connection URL construction for different database types"""
     # SQLite
-    sqlite_db = DatabaseSchema(type="sqlite", connection_string="/path/to/db.sqlite")
+    sqlite_db = DatabaseSchema(
+        type="sqlite", connection_string=Path("/path/to/db.sqlite")
+    )
     assert sqlite_db.get_connection_url() == "sqlite:////path/to/db.sqlite"
 
     # MySQL


### PR DESCRIPTION
This patch is intended to fix the permission inheritance of the sqlite
database when it is being created for the first time.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-1073](https://issues.redhat.com/browse/RSPEED-1073)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
