### PR TITLE
[RSPEED-1472] Increase request timeout to 60 seconds

### DIFF
--- a/command_line_assistant/daemon/http/query.py
+++ b/command_line_assistant/daemon/http/query.py
@@ -99,7 +99,7 @@ def _send_request(endpoint: str, payload: dict, config: Config) -> Response:
         return session.post(
             endpoint,
             json=payload,  # Uses json parameter instead of manually serializing
-            timeout=30,
+            timeout=60,
         )
 
 


### PR DESCRIPTION
This patch increases the timeout to 60 seconds instead of the default of 30.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-1472](https://issues.redhat.com/browse/RSPEED-1472)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
