### PR TITLE
Fix distribution-tarball to include schemas directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,6 @@ distribution-tarball: clean ## Generate distribution tarball
 		--exclude=.gitlab-ci.yml \
 		--exclude=.readthedocs.yaml \
 		--exclude=podman-compose.yaml \
-		--exclude=schemas \
 		--exclude=tox.ini \
 		--exclude=renovate.json \
 		--exclude=.pre-commit-config.yaml \


### PR DESCRIPTION
The schema directory was being excluded from the final distribution tarball

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
