### PR TITLE
[RSPEED-1064] Increase question/context size to 32k

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -74,8 +74,8 @@ timing = TimingLogger(
 )
 
 #: Max input size we want to allow to be submitted to the backend. This
-#: corresponds to 2KB (2048 bytes)
-MAX_QUESTION_SIZE: int = 2048
+#: corresponds to 32KB (32000 bytes)
+MAX_QUESTION_SIZE: int = 32000
 
 #: Legal notice that we need to output once per user
 LEGAL_NOTICE = (
@@ -341,23 +341,23 @@ class BaseChatOperation(BaseOperation):
         Returns:
             str: The response from the backend server
         """
-        final_question = _get_input_source(question, stdin, attachment, last_output)
         response = None
-
-        if len(final_question) > MAX_QUESTION_SIZE:
-            final_question_size = human_readable_size(len(final_question))
+        final_question = _get_input_source(question, stdin, attachment, last_output)
+        final_question_size = len(final_question)
+        if final_question_size >= MAX_QUESTION_SIZE:
+            readable_size = human_readable_size(final_question_size)
             max_question_size = human_readable_size(MAX_QUESTION_SIZE)
             self.warning_renderer.render(
-                f"The total size of your question and context ({final_question_size}) exceeds the limit of {max_question_size}. Trimming it down to fit in the expected size, you may lose some context."
+                f"The total size of your question and context ({readable_size}) exceeds the limit of {max_question_size}. Trimming it down to fit in the expected size, you may lose some context."
             )
             logger.debug(
                 "Total size of question (%s) exceeds defined limit of %s.",
-                len(final_question),
+                final_question_size,
                 MAX_QUESTION_SIZE,
             )
             final_question = final_question[:MAX_QUESTION_SIZE]
             logger.debug(
-                "Final size of question after the limit %s.", len(final_question)
+                "Final size of question after the limit %s.", final_question_size
             )
 
         if skip_spinner:

--- a/tests/commands/test_chat.py
+++ b/tests/commands/test_chat.py
@@ -605,17 +605,17 @@ def test_submit_question_no_spinner(mock_dbus_service, default_kwargs, capsys):
     captured = capsys.readouterr()
     assert "Asking RHEL Lightspeed" not in captured.out
 
-
 @pytest.mark.parametrize(
     ("question", "stdin", "attachment", "last_output"),
     (
-        ("test " * 2048, "", "", ""),
-        ("", "test " * 2048, "", ""),
-        ("", "", "test " * 2048, ""),
-        ("", "", "", "test " * 2048),
+        # This generate more than 32k output to match the condition
+        ("test " * 6500, "", "", ""),
+        ("", "test " * 6500, "", ""),
+        ("", "", "test " * 6500, ""),
+        ("", "", "", "test " * 6500),
         # Combining two or more sources
-        ("question " * 2048, "stdin " * 124, "", ""),
-        ("question " * 2048, "stdin " * 124, "attachment" * 124, "last_output" * 124),
+        ("question " * 6500, "stdin " * 124, "", ""),
+        ("question " * 6500, "stdin " * 124, "attachment" * 124, "last_output" * 124),
     ),
 )
 def test_trim_down_message_size(
@@ -645,10 +645,10 @@ def test_trim_down_message_size(
         last_output,
         True,
     )
-    assert result == "test"
+    assert "test" in result
     captured = capsys.readouterr()
     assert "The total size of your question and context" in captured.out
-    assert "Final size of question after the limit 2048." in caplog.records[-3].message
+    assert "Final size of question after the limit" in caplog.records[-3].message
 
 
 def test_submit_question_history_disabled(


### PR DESCRIPTION
The current 2k limit is not good enough and does not fit the customer needs anymore. We need to bump that in order to provide more meaningful answers to the users.

This 32k limit is to not overflow the LLM context window buffer.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-1064](https://issues.redhat.com/browse/RSPEED-1064)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
