### PR TITLE
[RSPEED-1574, RHEL-96351] try decoding the JSON and handle the error gracefully

### DIFF
--- a/tests/daemon/http/test_query.py
+++ b/tests/daemon/http/test_query.py
@@ -202,3 +202,29 @@ def test_extract_response_text_invalid_json(mock_config, default_payload):
 
     result = query.submit(default_payload, config=mock_config)
     assert result == "Not a JSON response"
+
+
+@responses.activate
+@pytest.mark.parametrize(
+    "status_code,response_body,expected_error_message",
+    [
+        (
+            HTTPStatus.NOT_FOUND,
+            "Not found",
+            "Resource not found: The requested endpoint doesn't exist. No additional details provided.",
+        )
+    ],
+)
+def test_handle_error_response_invalid_json(
+    mock_config, default_payload, status_code, response_body, expected_error_message
+):
+    """Test handling non-JSON error responses"""
+    responses.post(
+        url="http://localhost/infer",
+        status=status_code,
+        body=response_body,
+        content_type="text/plain",
+    )
+
+    with pytest.raises(RequestFailedError, match=expected_error_message):
+        query.submit(default_payload, config=mock_config)


### PR DESCRIPTION
If the response body cannot be decoded as JSON, log the exception and gracefully continue.

The current error message:

```
⁺₊+ Asking RHEL Lightspeed
Communication error with the server: Expecting value: line 1 column 1 (char 0). Please try again in a few minutes.
```

This PR changes the error message to look like:

```
⁺₊+ Asking RHEL Lightspeed
Access forbidden: You don't have permission to access this resource. No additional details provided.
```

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-1574](https://issues.redhat.com/browse/RSPEED-1574)
- [RHEL-96351](https://issues.redhat.com/browse/RHEL-96351)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
