### PR TITLE
[RSPEED-1647] Allow to pass terminal output without question or stdin

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -533,13 +533,6 @@ class SingleQuestionOperation(BaseChatOperation):
         Raises:
             ChatCommandException: In case the query has invalid sizing (less than 1 character).
         """
-        # If both are empty, raise exception
-        if not self.args.query_string and not self.args.stdin:
-            logger.debug("Both query_string and stdin are empty.")
-            raise ChatCommandException(
-                "Your query needs to have at least 2 characters. Either query or stdin are empty."
-            )
-
         # If query_string has content but is too short
         if self.args.query_string and len(self.args.query_string.strip()) <= 1:
             logger.debug(

--- a/docs/source/man/command-line-assistant.1.rst
+++ b/docs/source/man/command-line-assistant.1.rst
@@ -190,11 +190,12 @@ order to maintain a correct order of querying. The rules can be seen here::
     1. Positional query only -> use positional query
     2. Stdin query only -> use stdin query
     3. File query only -> use file query
-    4. Stdin + positional query -> combine as "{positional_query} {stdin}"
-    5. Stdin + file query -> combine as "{stdin} {file_query}"
-    6. Positional + file query -> combine as "{positional_query} {file_query}"
-    7. Positional + last output -> combine as "{positional_query} {last_output}"
-    8. Positional + attachment + last output -> combine as "{positional_query} {attachment} {last_output}"
+    4. Last terminal output -> use last terminal output
+    5. Stdin + positional query -> combine as "{positional_query} {stdin}"
+    6. Stdin + file query -> combine as "{stdin} {file_query}"
+    7. Positional + file query -> combine as "{positional_query} {file_query}"
+    8. Positional + last output -> combine as "{positional_query} {last_output}"
+    9. Positional + attachment + last output -> combine as "{positional_query} {attachment} {last_output}"
     99. All three sources -> use only positional and file as "{positional_query} {file_query}"
 
 Files


### PR DESCRIPTION
This is a regression found in the 0.4.0 build.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-1647](https://issues.redhat.com/browse/RSPEED-1647)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
