### PR TITLE
RSPEED-1626: packaging: Add tmpfiles.d config for /var folder

### DIFF
--- a/data/release/systemd/clad.tmpfiles.conf
+++ b/data/release/systemd/clad.tmpfiles.conf
@@ -1,0 +1,1 @@
+d /var/lib/command-line-assistant 0700 root root - -

--- a/packaging/command-line-assistant.spec
+++ b/packaging/command-line-assistant.spec
@@ -84,8 +84,9 @@ popd
 ln -sr %{buildroot}/%{_bindir}/%{binary_name} %{buildroot}/%{_bindir}/%{symlink_binary_name}
 ln -sr %{buildroot}%{_mandir}/man1/%{binary_name}.1 %{buildroot}%{_mandir}/man1/%{symlink_binary_name}.1
 
-# System units
+# System units & tmpfiles.d config
 %{__install} -D -m 0644 data/release/systemd/%{daemon_binary_name}.service %{buildroot}/%{_unitdir}/%{daemon_binary_name}.service
+%{__install} -D -m 0644 data/release/systemd/%{daemon_binary_name}.tmpfiles.conf %{buildroot}/%{_tmpfilesdir}/%{daemon_binary_name}.conf
 
 # d-bus policy config
 %{__install} -D -m 0644 data/release/dbus/com.redhat.lightspeed.conf %{buildroot}/%{_datadir}/dbus-1/system.d/com.redhat.lightspeed.conf


### PR DESCRIPTION
Fixes the following lint when installing on Bootable Containers:

```
Lint warning: var-tmpfiles: Found content in /var missing systemd tmpfiles.d entries:
  d /var/lib/command-line-assistant 0700 root root - -
```

Jira Issues:
- [RSPEED-1626](https://issues.redhat.com/browse/RSPEED-1626) (does not fix this issues but should helps with it)

Checklist

- [ ] Jira issue has been made public if possible (RH Internal only right now)
- [x] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [x] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
