### PR TITLE
Fix CommandContext to get user ID correctly by changing from os.getegid() to os.geteuid()

### DIFF
--- a/command_line_assistant/utils/cli.py
+++ b/command_line_assistant/utils/cli.py
@@ -46,7 +46,7 @@ class CommandContext:
     """
 
     username: str = getpass.getuser()
-    effective_user_id: int = os.getegid()
+    effective_user_id: int = os.geteuid()
 
     # Empty dictionary for os_release information. Parsed at the __post__init__ method.
     os_release: dict[str, str] = dataclasses.field(default_factory=dict)


### PR DESCRIPTION
The CommandContext was calling os.getegid and setting the result to its `effective_user_id` property. On most Linux systems, this never causes an issue because a user's UID and its primary GID are identical. Occasionally, on systems with a lot of manual user management this won't actually be the case, and a user's primary UID won't equal its primary GID. If that happens, the resulting computed UUID for the user won't be correct.

There's a chance that this change will cause existing chat histories to break since the integer being used to compute the UUID is changing. I sincerely doubt anyone will notice, but it's worth considering before merging this PR.