### PR TITLE
[RSPEED-1626] Add missing line for %files in rpmbuild

### DIFF
--- a/packaging/command-line-assistant.spec
+++ b/packaging/command-line-assistant.spec
@@ -140,6 +140,7 @@ fi
 
 # System units
 %{_unitdir}/%{daemon_binary_name}.service
+%{_tmpfilesdir}/%{daemon_binary_name}.conf
 
 # d-bus policy config
 %{_datadir}/dbus-1/system.d/com.redhat.lightspeed.conf


### PR DESCRIPTION
Since the introduction of the tmpfiles.d config to allow image mode testing, we missed to add this line to our %files section of the rpm.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-1626](https://issues.redhat.com/browse/RSPEED-1626)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
