### PR TITLE
[RHEL-95741] Fix terminal width handling in TextWrapDecorator

### DIFF
--- a/command_line_assistant/rendering/decorators/text.py
+++ b/command_line_assistant/rendering/decorators/text.py
@@ -92,7 +92,7 @@ class TextWrapDecorator(BaseDecorator):
             width (Optional[int], optional): The width of the terminal. Defaults to `shutil.get_terminal_size().columns`.
             indent (str, optional): Indentation mode for the string. Defaults to "".
         """
-        self._width = width or shutil.get_terminal_size().columns
+        self._width = width or shutil.get_terminal_size().columns or 80
         self._indent = indent
 
     def decorate(self, text: str) -> str:

--- a/tests/rendering/decorators/test_text.py
+++ b/tests/rendering/decorators/test_text.py
@@ -1,5 +1,6 @@
 import shutil
 from typing import Iterator
+from unittest.mock import patch
 
 import pytest
 
@@ -84,6 +85,19 @@ class TestTextWrapDecorator:
         """Test text wrap decorator with custom indent"""
         decorator = TextWrapDecorator(indent="  ")
         assert decorator._indent == "  "
+
+    @patch("shutil.get_terminal_size")
+    def test_zero_terminal_width(self, mock_get_terminal_size):
+        """Test text wrap decorator when terminal width is detected as 0"""
+        # Mock terminal size to return 0 columns
+        mock_terminal_size = type("TerminalSize", (), {"columns": 0, "lines": 24})()
+        mock_get_terminal_size.return_value = mock_terminal_size
+
+        decorator = TextWrapDecorator()
+        result = decorator.decorate("Hello world")
+
+        assert isinstance(result, str)
+        assert result is not None
 
     @pytest.mark.parametrize(
         ("width", "indent", "text", "expected"),


### PR DESCRIPTION
When the terminal width value returned from shutil.get_terminal_size is 0, coalecse the value to 80 instead. This fixes an exception being raised later by the renderer.

Fixes: RHEL-95741
