### PR TITLE
[RSPEED-1564] Add horizontal line after spinner message

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -252,7 +252,7 @@ class BaseChatOperation(BaseOperation):
         """
         if _handle_legal_message():
             self.notice_renderer.render(LEGAL_NOTICE)
-    
+
         self.text_renderer.render("─" * 72)
         print("")
 

--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -252,8 +252,9 @@ class BaseChatOperation(BaseOperation):
         """
         if _handle_legal_message():
             self.notice_renderer.render(LEGAL_NOTICE)
-            self.text_renderer.render("─" * 72)
-            print("")
+    
+        self.text_renderer.render("─" * 72)
+        print("")
 
         self.markdown_renderer.render(response)
         print("")


### PR DESCRIPTION
Adding a new horizontal line after the spinner text to make it more readable

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-1564](https://issues.redhat.com/browse/RSPEED-1564)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
