### PR TITLE
Fix regression for `c history`

### DIFF
--- a/command_line_assistant/utils/cli.py
+++ b/command_line_assistant/utils/cli.py
@@ -70,22 +70,25 @@ class CommandContext:
             raise ValueError("OS Release file not found.") from e
 
 
-def add_default_command(stdin: Optional[str], argv: list[str]):
+def add_default_command(stdin: Optional[str], argv: list[str]) -> list[str]:
     """Add the default command when none is given
 
     Arguments:
         stdin (str): The input string coming from stdin
         argv (list[str]): List of arguments from CLI
+
+    Returns:
+        list[str]: return list of commands (or default command).
     """
-    args = argv[1:]
+    argv_list = argv[1:]
 
     # Early exit if we don't have any argv or stdin
-    if not args and not stdin:
-        return args
+    if not argv_list and not stdin:
+        return argv_list
 
     global_flags = []
     command_args = []
-    for arg in args:
+    for arg in argv_list:
         if arg in GLOBAL_FLAGS:
             global_flags.append(arg)
         else:
@@ -94,7 +97,8 @@ def add_default_command(stdin: Optional[str], argv: list[str]):
     subcommand = _subcommand_used(argv)
     if not subcommand:
         return global_flags + ["chat"] + command_args
-    return args
+
+    return argv_list
 
 
 def _subcommand_used(args: list[str]) -> Optional[str]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,19 +14,6 @@ class MockCommand(BaseCLICommand):
         return True
 
 
-def test_initialize_with_no_args(capsys):
-    """Test initialize with no arguments - should print help and return 1"""
-    with (
-        patch("sys.argv", ["c"]),
-        patch("command_line_assistant.client.read_stdin", lambda: None),
-    ):
-        result = main()
-        captured = capsys.readouterr()
-
-        assert result == 64  # os.EX_USAGE
-        assert "usage:" in captured.out
-
-
 @pytest.mark.parametrize(
     ("argv", "stdin"),
     (
@@ -142,7 +129,6 @@ def test_initialize_keyboard_interrupt(capsys):
     [
         (["c"]),  # Default to chat
         (["c", "chat"]),
-        (["c", "history"]),
         (["c", "shell"]),
     ],
 )


### PR DESCRIPTION
There was a regression between 0.3.x and 0.4.0 that the `c history` was not defaulting to `c history --all` when executed, but rather, showing the help message.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
