### PR TITLE
Fix round sizing for human readable numbers

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -336,7 +336,7 @@ class BaseChatOperation(BaseOperation):
             readable_size = human_readable_size(len(value))
             max_question_size = human_readable_size(MAX_QUESTION_SIZE)
             self.warning_renderer.render(
-                f"The total size of your input '{source}' ({readable_size}) exceeds the limit of {max_question_size}. "
+                f"The total size of your input from '{source}' (approximaely {readable_size}) exceeds the limit of {max_question_size}. "
                 "Trimming it down to fit in the expected size, you may lose some context."
             )
             logger.debug(

--- a/command_line_assistant/utils/renderers.py
+++ b/command_line_assistant/utils/renderers.py
@@ -156,8 +156,8 @@ def human_readable_size(size: float) -> str:
     units = ["B", "KB", "MB", "GB", "TB", "PB"]
     unit_index = 0
 
-    while size >= 1024 and unit_index < len(units) - 1:
-        size /= 1024
+    while size >= 1000 and unit_index < len(units) - 1:
+        size /= 1000
         unit_index += 1
 
     return f"{size:.2f} {units[unit_index]}"

--- a/tests/utils/test_renderers.py
+++ b/tests/utils/test_renderers.py
@@ -34,19 +34,45 @@ def test_create_text_renderer(capsys: pytest.CaptureFixture[str]):
     renderer.render("errored out")
 
     captured = capsys.readouterr()
-    print(captured)
     assert "rrored out\n" in captured.out
 
 
 @pytest.mark.parametrize(
     ("size", "expected"),
     (
+        # Test bytes (< 1000)
+        (0, "0.00 B"),
+        (1, "1.00 B"),
+        (42, "42.00 B"),
         (248, "248.00 B"),
-        (2048, "2.00 KB"),
-        (2000048, "1.91 MB"),
-        (2000000048, "1.86 GB"),
-        (2000000000408, "1.82 TB"),
-        (2000000000000408, "1.78 PB"),
+        (567, "567.00 B"),
+        (999, "999.00 B"),
+        # Test KB boundary and values
+        (1000, "1.00 KB"),
+        (999999, "1000.00 KB"),
+        # Test MB boundary and values
+        (1000000, "1.00 MB"),
+        (999999999, "1000.00 MB"),
+        # Test GB boundary and values
+        (1000000000, "1.00 GB"),
+        (999999999999, "1000.00 GB"),
+        # Test TB boundary and values
+        (1000000000000, "1.00 TB"),
+        # Test PB boundary and values
+        (1000000000000000, "1.00 PB"),
+        # Test float inputs
+        (1500.5, "1.50 KB"),
+        (2500.75, "2.50 KB"),
+        (32000, "32.00 KB"),
+        (1234567.89, "1.23 MB"),
+        (9876543210.123, "9.88 GB"),
+        # Test edge cases and random values
+        (1234567, "1.23 MB"),
+        (9876543, "9.88 MB"),
+        (123456789, "123.46 MB"),
+        (987654321, "987.65 MB"),
+        (1234567890, "1.23 GB"),
+        (9876543210, "9.88 GB"),
     ),
 )
 def test_human_readable_size(size, expected):


### PR DESCRIPTION
We found an inconsistency that was rounding down the numbers and not showing it accurately.

Example of this is that we have a hard limit for 32k and the `human_readable_size` function was rounding that numer for 31.2k.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
