### PR TITLE
[RSPEED-1762] Catch OSError being thrown by submit method

### DIFF
--- a/command_line_assistant/daemon/http/query.py
+++ b/command_line_assistant/daemon/http/query.py
@@ -83,6 +83,14 @@ def submit(payload: dict, config: Config) -> str:
         raise RequestFailedError(
             f"Communication error with the server: {str(exc)}. Please try again in a few minutes."
         ) from exc
+    except OSError as exc:
+        # If the exception string contains the standard RHSM cert path, assume
+        # the system is not registered and raise a very specific error message.
+        if "/etc/pki/consumer/cert.pem" in str(exc):
+            raise RequestFailedError(
+                "The system must be registered to use RHEL Lightspeed. For cloud-based systems, see: https://access.redhat.com/articles/7127962"
+            ) from exc
+        raise exc
 
 
 def _send_request(endpoint: str, payload: dict, config: Config) -> Response:


### PR DESCRIPTION
When the submit method throws an error, catch OSErrors and inspect the message. If it contains "/etc/pki/consumer/cert.pem" (the default file path for the RHSM consumer certificate), assume the system is not registered with RHSM and raise a custom error string recommending the user connect the system using rhc.

```
[link@localhost ~]$ c "What is RHEL Lightspeed?"
⁺₊+ Asking RHEL Lightspeed
System is not registered with Red Hat. Run `subscription-manager register` or `rhc connect` and try again.
[link@localhost ~]$
```

Fixes: RSPEED-1762
Fixes: RHEL-102629
Fixes: #335