### PR TITLE
Change pre-commit autoupdate schedule to monthly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,12 @@
+minimum_pre_commit_version: "3.8.0"
+
 ci:
   skip:
     # rpm library is not available in the CI
     - rpmlint
-
-minimum_pre_commit_version: "3.8.0"
+  
+  # run autopdate monthly to reduce PR noise
+  autoupdate_schedule: 'monthly'
 
 repos:
   - repo: https://github.com/rpm-software-management/rpmlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
   skip:
     # rpm library is not available in the CI
     - rpmlint
-  
+
   # run autopdate monthly to reduce PR noise
   autoupdate_schedule: 'monthly'
 


### PR DESCRIPTION
pre-commit is being too noise trying to update the modules every week. Sometimes it only updates 1 repository. To avoid having to merge every single week the updates, let's run this monthly instead

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
