### PR TITLE
[RSPEED-1796] Fix typo in warning message for total input size

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -336,7 +336,7 @@ class BaseChatOperation(BaseOperation):
             readable_size = human_readable_size(len(value))
             max_question_size = human_readable_size(MAX_QUESTION_SIZE)
             self.warning_renderer.render(
-                f"The total size of your input from '{source}' (approximaely {readable_size}) exceeds the limit of {max_question_size}. "
+                f"The total size of your input from '{source}' (approximately {readable_size}) exceeds the limit of {max_question_size}. "
                 "Trimming it down to fit in the expected size, you may lose some context."
             )
             logger.debug(


### PR DESCRIPTION
We had a typo in the total input size warning message we emit when the total attachment size is over 32k

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-1796](https://issues.redhat.com/browse/RSPEED-1796)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
