### PR TITLE
Add multi-arch builds in Konflux

### DIFF
--- a/.tekton/pipeline-build.yaml
+++ b/.tekton/pipeline-build.yaml
@@ -54,7 +54,7 @@ spec:
 
     - name: build-image-index
       description: Add built image into an OCI image index
-      default: "false"
+      default: "true"
 
     - name: build-args
       description: Array of --build-arg values ("arg=value" strings) for buildah
@@ -76,14 +76,21 @@ spec:
       type: array
       default: []
 
+    - name: build-platforms
+      description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
+      type: array
+      default:
+        - linux/x86_64
+        - linux/arm64
+
   results:
     - name: IMAGE_URL
       description: ""
-      value: $(tasks.build-container.results.IMAGE_URL)
+      value: $(tasks.build-image-index.results.IMAGE_URL)
 
     - name: IMAGE_DIGEST
       description: ""
-      value: $(tasks.build-container.results.IMAGE_DIGEST)
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
 
     - name: CHAINS-GIT_URL
       description: ""
@@ -192,7 +199,12 @@ spec:
         - name: netrc
           workspace: netrc
 
-    - name: build-container
+    - matrix:
+        params:
+        - name: PLATFORM
+          value:
+          - $(params.build-platforms)
+      name: build-container
       params:
         - name: IMAGE
           value: $(params.output-image)
@@ -228,6 +240,9 @@ spec:
         - name: CACHI2_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
 
+        - name: IMAGE_APPEND_PLATFORM
+          value: "true"
+
       runAfter:
         - prefetch-dependencies
 
@@ -235,10 +250,10 @@ spec:
         resolver: bundles
         params:
           - name: name
-            value: buildah-oci-ta
+            value: buildah-remote-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:48b99ad18fd3bde2d22ec2c397d36c55e45ca90ddf1620c9e00bdee518e297bf
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:5b8d51fa889cdac873750904c3fccc0cca1c4f65af16902ebb2b573151f80657
 
           - name: kind
             value: task
@@ -265,7 +280,7 @@ spec:
 
         - name: IMAGES
           value:
-            - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+            - $(tasks.build-container.results.IMAGE_REF[*])
 
       runAfter:
         - build-container
@@ -290,10 +305,10 @@ spec:
     - name: deprecated-base-image-check
       params:
         - name: IMAGE_URL
-          value: $(tasks.build-container.results.IMAGE_URL)
+          value: $(tasks.build-image-index.results.IMAGE_URL)
 
         - name: IMAGE_DIGEST
-          value: $(tasks.build-container.results.IMAGE_DIGEST)
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
 
       runAfter:
         - build-image-index
@@ -319,10 +334,10 @@ spec:
     - name: clair-scan
       params:
         - name: image-digest
-          value: $(tasks.build-container.results.IMAGE_DIGEST)
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
 
         - name: image-url
-          value: $(tasks.build-container.results.IMAGE_URL)
+          value: $(tasks.build-image-index.results.IMAGE_URL)
 
       runAfter:
         - build-image-index
@@ -347,7 +362,7 @@ spec:
     - name: ecosystem-cert-preflight-checks
       params:
         - name: image-url
-          value: $(tasks.build-container.results.IMAGE_URL)
+          value: $(tasks.build-image-index.results.IMAGE_URL)
 
       runAfter:
         - build-image-index
@@ -372,10 +387,10 @@ spec:
     - name: sast-snyk-check
       params:
         - name: image-digest
-          value: $(tasks.build-container.results.IMAGE_DIGEST)
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
 
         - name: image-url
-          value: $(tasks.build-container.results.IMAGE_URL)
+          value: $(tasks.build-image-index.results.IMAGE_URL)
 
         - name: SOURCE_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
@@ -410,10 +425,10 @@ spec:
     - name: clamav-scan
       params:
         - name: image-digest
-          value: $(tasks.build-container.results.IMAGE_DIGEST)
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
 
         - name: image-url
-          value: $(tasks.build-container.results.IMAGE_URL)
+          value: $(tasks.build-image-index.results.IMAGE_URL)
 
       runAfter:
         - build-image-index
@@ -600,7 +615,7 @@ spec:
     - name: apply-tags
       params:
         - name: IMAGE_URL
-          value: $(tasks.build-container.results.IMAGE_URL)
+          value: $(tasks.build-image-index.results.IMAGE_URL)
 
         - name: IMAGE_DIGEST
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)
@@ -628,10 +643,10 @@ spec:
     - name: push-dockerfile
       params:
         - name: IMAGE
-          value: $(tasks.build-container.results.IMAGE_URL)
+          value: $(tasks.build-image-index.results.IMAGE_URL)
 
         - name: IMAGE_DIGEST
-          value: $(tasks.build-container.results.IMAGE_DIGEST)
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
 
         - name: DOCKERFILE
           value: $(params.dockerfile)
@@ -660,10 +675,10 @@ spec:
     - name: rpms-signature-scan
       params:
         - name: image-digest
-          value: $(tasks.build-container.results.IMAGE_DIGEST)
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
 
         - name: image-url
-          value: $(tasks.build-container.results.IMAGE_URL)
+          value: $(tasks.build-image-index.results.IMAGE_URL)
 
       runAfter:
         - build-image-index
@@ -684,7 +699,7 @@ spec:
     - name: show-sbom
       params:
         - name: IMAGE_URL
-          value: $(tasks.build-container.results.IMAGE_URL)
+          value: $(tasks.build-image-index.results.IMAGE_URL)
 
       taskRef:
         resolver: bundles

--- a/.tekton/pull_request.yaml
+++ b/.tekton/pull_request.yaml
@@ -11,7 +11,7 @@ metadata:
   creationTimestamp: null
 
   labels:
-    appstudio.openshift.io/application: command-line-assistant
+    appstudio.openshift.io/application: rhel-cla
     appstudio.openshift.io/component: command-line-assistant
     pipelines.appstudio.openshift.io/type: build
 

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -11,7 +11,7 @@ metadata:
   creationTimestamp: null
 
   labels:
-    appstudio.openshift.io/application: command-line-assistant
+    appstudio.openshift.io/application: rhel-cla
     appstudio.openshift.io/component: command-line-assistant
     pipelines.appstudio.openshift.io/type: build
 

--- a/container-images/default.Containerfile
+++ b/container-images/default.Containerfile
@@ -27,6 +27,12 @@ RUN python3 -m venv /opt/venvs/uv \
 
 FROM base AS final
 
+# Add in data about the build. (These come from Konflux.)
+ARG COMMIT_SHA=development
+ARG COMMIT_TIMESTAMP=development
+ARG VERSION=0.4.2
+ARG SOURCE_DATE_EPOCH
+
 # Labels for enterprise contract
 LABEL com.redhat.component=rhel-lightspeed-command-line-assistant
 LABEL description="Red Hat Enterprise Linux Lightspeed"
@@ -35,16 +41,12 @@ LABEL io.k8s.description="Red Hat Enterprise Linux Lightspeed"
 LABEL io.k8s.display-name="RHEL Lightspeed"
 LABEL io.openshift.tags="rhel,lightspeed,ai,assistant,rag"
 LABEL name=rhel-lightspeed-command-line-assistant
+LABEL org.opencontainers.image.created=${SOURCE_DATE_EPOCH}
 LABEL release="${VERSION}"
 LABEL version=${VERSION}
 LABEL url="https://github.com/rhel-lightspeed/command-line-assistant"
 LABEL vendor="Red Hat, Inc."
 LABEL summary="Red Hat Enterprise Linux Lightspeed"
-
-# Add in data about the build. (These come from Konflux.)
-ARG COMMIT_SHA=development
-ARG COMMIT_TIMESTAMP=development
-ARG VERSION=0.4.2
 
 ENV CLA_VENV /opt/venvs/cla
 


### PR DESCRIPTION
Adjusting the .tekton build pipeline to perform multi-arch builds for CLA in x86_64 and arm64.

<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
-

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
