### PR TITLE
[RSPEED-2134] Fix line ending after spinner stops

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -369,9 +369,9 @@ def _display_response(renderer: Renderer, response: str) -> None:
         renderer.notice(LEGAL_NOTICE)
 
     renderer.notice("─" * 72)
-    print("")
+    renderer.normal("")
     renderer.markdown(response)
-    print("")
+    renderer.normal("")
     renderer.notice("─" * 72)
     renderer.notice(ALWAYS_LEGAL_MESSAGE)
 

--- a/command_line_assistant/rendering/animation.py
+++ b/command_line_assistant/rendering/animation.py
@@ -67,8 +67,5 @@ class Spinner:
                 self._animation_thread.join()
             self._spinning = False
 
-            # Clear the animation line and add a newline
-            if self._current_line_length > 0:
-                clear_line = "\r" + " " * self._current_line_length + "\r"
-                sys.stderr.write(clear_line)
-                sys.stderr.flush()
+            sys.stderr.write("\n")
+            sys.stderr.flush()

--- a/command_line_assistant/rendering/stream.py
+++ b/command_line_assistant/rendering/stream.py
@@ -34,12 +34,6 @@ class StreamWriter:
         self._flush_on_write = flush_on_write
         self._theme = theme or Theme()
 
-    def write_chunk(self, chunk: str) -> None:
-        """Write a chunk of unformatted text to the stream."""
-        self._stream.write(chunk)
-        if self._flush_on_write:
-            self._stream.flush()
-
     def write_line(self, line: str) -> None:
         """Write a line of unformatted text to the stream."""
         self._stream.write(line + "\n")
@@ -67,7 +61,7 @@ class StreamWriter:
             formatted_content = markdown_to_ansi(content_to_render, theme=self._theme)
 
             # If successful, write to stream and clear buffer
-            self._stream.write(formatted_content)
+            self.write_line(formatted_content)
             self._buffer = ""
 
             if self._flush_on_write:


### PR DESCRIPTION
<!-- Write a description of what the PR solves and how -->

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:

<!-- List below in format of [RSPEED-](https://issues.redhat.com/browse/RSPEED-) -->
- [RSPEED-2134](https://issues.redhat.com/browse/RSPEED-2134)

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
