### PR TITLE
[RSPEED-3420] Adjust the legal disclaimer when not using RH managed endpoint

### DIFF
--- a/command_line_assistant/commands/chat.py
+++ b/command_line_assistant/commands/chat.py
@@ -64,8 +64,11 @@ MAX_QUESTION_SIZE: int = 32_000
 #: Legal notice that we need to output once per user
 LEGAL_NOTICE = (
     "This feature uses AI technology. Do not include any personal information or "
-    "other sensitive information in your input. Interactions may be used to "
-    "improve Red Hat's products or services."
+    "other sensitive information in your input."
+)
+#: Additional legal notice shown only when connected to Red Hat managed endpoints
+LEGAL_NOTICE_RHSM = (
+    "Interactions may be used to improve Red Hat's products or services."
 )
 #: Always good to have legal message.
 ALWAYS_LEGAL_MESSAGE = "Always review AI-generated content prior to use."
@@ -357,16 +360,24 @@ def _create_chat_session(
     return dbus.chat_proxy.CreateChat(user_id, name, description)
 
 
-def _display_response(renderer: Renderer, response: str) -> None:
+def _display_response(
+    renderer: Renderer, response: str, show_rhsm_notice: bool = False
+) -> None:
     """Display message to the terminal.
 
     Args:
         renderer (Renderer): The renderer to use.
         response (str): The response to display.
+        show_rhsm_notice (bool): When True, also display the Red Hat managed
+            service legal notice about interactions being used to improve
+            products or services. Should only be True for Red Hat managed
+            endpoints. Defaults to False.
     """
 
     if _handle_legal_message():
         renderer.notice(LEGAL_NOTICE)
+        if show_rhsm_notice:
+            renderer.notice(LEGAL_NOTICE_RHSM)
 
     renderer.notice("─" * 72)
     renderer.normal("")
@@ -620,13 +631,13 @@ def _interactive_chat(
 
     input_source = _gather_input_sources(args)
     chat_id = _create_chat_session(dbus, user_id, name, description)
-
-    # Display banner message
-    render.normal(
-        "Welcome to the interactive mode for command line assistant! To exit, press Ctrl + C or type '.exit'.\nThe current session does not include running context."
-    )
+    is_rhsm_managed_endpoint = dbus.chat_proxy.IsRedHatManagedEndpoint()
 
     try:
+        # Display banner message
+        render.normal(
+            "Welcome to the interactive mode for command line assistant! To exit, press Ctrl + C or type '.exit'.\nThe current session does not include running context."
+        )
         while True:
             try:
                 question = input(">>> ").strip()
@@ -651,7 +662,11 @@ def _interactive_chat(
                 message_input=message_input,
                 plain=args.plain,
             )
-            _display_response(render, response)
+            _display_response(
+                render,
+                response,
+                show_rhsm_notice=is_rhsm_managed_endpoint,
+            )
     except KeyboardInterrupt:
         raise ChatCommandException(
             "Detected keyboard interrupt. Stopping interactive mode."
@@ -693,6 +708,7 @@ def _single_question(
 
     input_source = _gather_input_sources(args)
     message_input = _compose_message_input(render, context, input_source)
+    is_rhsm_managed_endpoint = dbus.chat_proxy.IsRedHatManagedEndpoint()
 
     try:
         chat_id = _create_chat_session(dbus, user_id, name, description)
@@ -703,8 +719,11 @@ def _single_question(
             message_input=message_input,
             plain=args.plain,
         )
-
-        _display_response(render, response)
+        _display_response(
+            render,
+            response,
+            show_rhsm_notice=is_rhsm_managed_endpoint,
+        )
         return 0
     except ValueError as e:
         message = f"Failed to get a response from LLM. {str(e)}"

--- a/command_line_assistant/commands/feedback.py
+++ b/command_line_assistant/commands/feedback.py
@@ -4,6 +4,7 @@ import logging
 from argparse import Namespace
 
 from command_line_assistant.commands.cli import CommandContext, argument, command
+from command_line_assistant.dbus.client import DbusClient
 from command_line_assistant.rendering.renderers import Renderer
 from command_line_assistant.rendering.theme import Theme
 
@@ -23,12 +24,17 @@ logger = logging.getLogger(__name__)
 def feedback_command(args: Namespace, context: CommandContext) -> int:
     """Feedback command implementation."""
     render = Renderer(args.plain, theme=Theme())
+    dbus = DbusClient()
 
-    render.notice(
+    notice_message = (
         "Do not include any personal information or other"
-        " sensitive information in your feedback. Feedback may"
-        " be used to improve Red Hat's products or services."
+        " sensitive information in your feedback."
     )
+    if dbus.chat_proxy.IsRedHatManagedEndpoint():
+        notice_message += (
+            " Feedback may be used to improve Red Hat's products or services."
+        )
+    render.notice(notice_message)
 
     feedback_message = "To submit feedback, use the following email address: <cla-feedback@redhat.com>."
     render.normal(feedback_message)

--- a/command_line_assistant/config/__init__.py
+++ b/command_line_assistant/config/__init__.py
@@ -67,7 +67,7 @@ def load_config_file() -> Config:
     config_file_path = Path(get_xdg_config_path(), *CONFIG_FILE_DEFINITION)
 
     try:
-        print(f"Loading configuration file from {config_file_path}")
+        logger.debug("Loading configuration file from %s", config_file_path)
         data = config_file_path.read_text()
         config_dict = tomllib.loads(data)
     except (FileNotFoundError, tomllib.TOMLDecodeError) as ex:

--- a/command_line_assistant/config/schemas/backend.py
+++ b/command_line_assistant/config/schemas/backend.py
@@ -7,6 +7,15 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+#: Hostnames of Red Hat managed endpoints that require displaying the legal
+#: notice about interactions being used to improve products or services.
+#: Only the hostname is stored here so that any API version or path on a
+#: managed host is correctly identified without requiring updates to this list.
+RHSM_MANAGED_HOSTNAMES: tuple[str, ...] = (
+    "cert.console.redhat.com",
+    "cert.console.stage.redhat.com",
+)
+
 
 @dataclasses.dataclass
 class AuthSchema:

--- a/command_line_assistant/dbus/interfaces/chat.py
+++ b/command_line_assistant/dbus/interfaces/chat.py
@@ -3,11 +3,13 @@
 import logging
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlparse
 
 from dasbus.server.interface import dbus_interface
 from dasbus.server.template import InterfaceTemplate
 from dasbus.typing import Str, Structure
 
+from command_line_assistant.config.schemas.backend import RHSM_MANAGED_HOSTNAMES
 from command_line_assistant.constants import VERSION
 from command_line_assistant.daemon.database.manager import DatabaseManager
 from command_line_assistant.daemon.database.repository.chat import ChatRepository
@@ -254,6 +256,23 @@ class ChatInterface(InterfaceTemplate, DBusAuthorizationMixin):
             user_id,
         )
         return str(result[0].id)
+
+    def IsRedHatManagedEndpoint(self) -> bool:
+        """Return whether the configured backend endpoint is a Red Hat managed endpoint.
+
+        The daemon reads the configuration and checks if the configured endpoint
+        is in the list of known Red Hat managed endpoints. This allows unprivileged
+        client processes (which cannot read the config file directly) to determine
+        whether the Red Hat legal notice should be displayed.
+
+        Returns:
+            bool: True if the endpoint is a known Red Hat managed endpoint,
+                  False otherwise.
+        """
+        return (
+            urlparse(self.implementation.config.backend.endpoint).hostname
+            in RHSM_MANAGED_HOSTNAMES
+        )
 
     def CreateChat(self, user_id: Str, name: Str, description: Str) -> Str:
         """Create a new chat session for a given conversation.

--- a/tests/commands/test_chat.py
+++ b/tests/commands/test_chat.py
@@ -493,6 +493,35 @@ def test_display_response(plain, capsys, tmp_path, monkeypatch, disable_stream_f
     assert "" in captured.out
 
 
+def test_display_response_without_rhsm_notice(
+    capsys, tmp_path, monkeypatch, disable_stream_flush
+):
+    """Test that the RHSM legal notice is not shown when show_rhsm_notice=False."""
+    monkeypatch.setattr(chat, "get_xdg_state_path", lambda: tmp_path)
+
+    chat._display_response(
+        Renderer(plain=True), "test response", show_rhsm_notice=False
+    )
+
+    captured = capsys.readouterr()
+    assert "Interactions may be used to improve" not in captured.out
+
+
+def test_display_response_with_rhsm_notice(
+    capsys, tmp_path, monkeypatch, disable_stream_flush
+):
+    """Test that the RHSM legal notice is shown when show_rhsm_notice=True."""
+    monkeypatch.setattr(chat, "get_xdg_state_path", lambda: tmp_path)
+
+    chat._display_response(Renderer(plain=True), "test response", show_rhsm_notice=True)
+
+    captured = capsys.readouterr()
+    assert (
+        "Interactions may be used to improve Red Hat's products or services."
+        in captured.out
+    )
+
+
 def test_submit_question_success(mock_dbus_service):
     """Test submitting question successfully."""
 

--- a/tests/commands/test_feedback.py
+++ b/tests/commands/test_feedback.py
@@ -77,20 +77,56 @@ def test_feedback_command_submit_false(command_context, capsys, disable_stream_f
 
 
 def test_feedback_command_warning_message_content(
-    default_namespace, command_context, capsys, disable_stream_flush
+    mock_dbus_service, default_namespace, command_context, capsys, disable_stream_flush
 ):
-    """Test that the warning message contains expected content."""
+    """Test that the warning message contains expected content.
+
+    The conditional "may be used to improve..." sentence must NOT appear when
+    the daemon reports a non-managed endpoint.
+    """
+    mock_dbus_service.IsRedHatManagedEndpoint.return_value = False
 
     feedback.feedback_command.func(default_namespace, command_context)
 
     captured = capsys.readouterr()
     warning_output = captured.out
 
-    # Check key parts of the warning message
+    # Check key parts of the unconditional warning message
     assert "Do not include any personal information" in warning_output
     assert "other sensitive information" in warning_output
     assert "in your feedback" in warning_output
-    assert "may be used to improve Red Hat's products or services" in warning_output
+    # The RHSM sentence is conditional on the daemon reporting a managed endpoint
+    assert "may be used to improve Red Hat's products or services" not in warning_output
+
+
+def test_feedback_command_warning_managed_endpoint(
+    mock_dbus_service, command_context, capsys, disable_stream_flush
+):
+    """Test that the RHSM sentence IS shown when the daemon reports an RH managed endpoint."""
+    mock_dbus_service.IsRedHatManagedEndpoint.return_value = True
+
+    args = Namespace(submit=True, plain=True)
+    result = feedback.feedback_command.func(args, command_context)
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "Do not include any personal information" in captured.out
+    assert "may be used to improve Red Hat's products or services" in captured.out
+
+
+def test_feedback_command_warning_non_managed_endpoint(
+    mock_dbus_service, command_context, capsys, disable_stream_flush
+):
+    """Test that the RHSM sentence is NOT shown when the daemon reports a non-managed endpoint."""
+    mock_dbus_service.IsRedHatManagedEndpoint.return_value = False
+
+    args = Namespace(submit=True, plain=True)
+    result = feedback.feedback_command.func(args, command_context)
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "Do not include any personal information" in captured.out
+    assert "may be used to improve Red Hat's products or services" not in captured.out
 
 
 def test_feedback_command_success_message_content(

--- a/tests/config/schemas/test_backend.py
+++ b/tests/config/schemas/test_backend.py
@@ -1,4 +1,7 @@
-from command_line_assistant.config.schemas.backend import AuthSchema
+from command_line_assistant.config.schemas.backend import (
+    RHSM_MANAGED_HOSTNAMES,
+    AuthSchema,
+)
 
 
 # TODO(r0x0d): Once we remove the depreaction notice, remove this as well.
@@ -11,4 +14,12 @@ def test_verify_ssl_deprecation_notice(caplog):
     assert (
         "Ignoring Verify SSL option as it has no effect anymore."
         in caplog.records[-1].message
+    )
+
+
+def test_rhsm_managed_hostnames_constant():
+    """Test that RHSM_MANAGED_HOSTNAMES contains the expected Red Hat managed hostnames."""
+    assert RHSM_MANAGED_HOSTNAMES == (
+        "cert.console.redhat.com",
+        "cert.console.stage.redhat.com",
     )

--- a/tests/dbus/interfaces/test_chat.py
+++ b/tests/dbus/interfaces/test_chat.py
@@ -72,6 +72,23 @@ def test_chat_interface_ask_question(chat_interface, mock_config, mock_authoriza
         assert reconstructed.message == expected_response
 
 
+def test_get_is_rhsm_managed_endpoint_false(chat_interface):
+    """Test that IsRedHatManagedEndpoint returns False for non-managed endpoints.
+
+    The mock_config fixture uses endpoint="http://localhost" which is not in
+    RHSM_MANAGED_ENDPOINTS.
+    """
+    result = chat_interface.IsRedHatManagedEndpoint()
+    assert result is False
+
+
+def test_get_is_rhsm_managed_endpoint_true(chat_interface, mock_config):
+    """Test that IsRedHatManagedEndpoint returns True for RH managed endpoints."""
+    mock_config.backend.endpoint = "https://cert.console.redhat.com/api/lightspeed/v1"
+    result = chat_interface.IsRedHatManagedEndpoint()
+    assert result is True
+
+
 def test_get_all_chat_from_user(chat_interface, mock_repository, mock_authorization):
     uid = "2345f9e6-dfea-11ef-9ae9-52b437312584"
     mock_repository.insert({"name": "test", "description": "test", "user_id": uid})


### PR DESCRIPTION
Resolves: 

Remove the "Interactions may be used to improve Red Hat's products or services." message when using the offline containers. 

<!-- Link to relevant Red Hat Jira issues -->
Jira Issues:
- https://redhat.atlassian.net/browse/RSPEED-3420

Checklist

- [ ] Jira issue has been made public if possible
- [ ] `[RSPEED-]` is part of the PR title <!-- For a proper sync with Jira -->
- [ ] PR title explains the change from the user's point of view
- [ ] Code and tests are documented properly
- [ ] The commits are squashed to as few commits as possible (without losing data) <!-- The commits can be squashed to 1 commit, but then we might lose data regarding moving something to a new file and then refactoring for example. Hence squash without losing data -->
