### PR TITLE
Prepare release 0.5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ XDG_CONFIG_DIRS := $(subst /,\/,$(DATA_DEVELOPMENT_PATH)/xdg)
 UV = $(shell command -v uv || echo "$$HOME/.local/bin/uv")
 
 PKGNAME := command-line-assistant
-VERSION := 0.5.1
+VERSION := 0.5.2
 
 default: help
 

--- a/command_line_assistant/constants.py
+++ b/command_line_assistant/constants.py
@@ -1,4 +1,4 @@
 """Module to track constants for the project."""
 
 #: Define the version for the program
-VERSION = "0.5.1"
+VERSION = "0.5.2"

--- a/data/release/man/c.1
+++ b/data/release/man/c.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "C" "1" "Aug 06, 2026" "0.5.1" "command-line assistant"
+.TH "C" "1" "Aug 11, 2026" "0.5.2" "command-line assistant"
 .SH NAME
 c \- command-line assistant client
 .SH SYNOPSIS

--- a/data/release/man/clad.8
+++ b/data/release/man/clad.8
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "CLAD" "8" "Aug 06, 2026" "0.5.1" "command-line assistant"
+.TH "CLAD" "8" "Aug 11, 2026" "0.5.2" "command-line assistant"
 .SH NAME
 clad \- command-line assistant daemon
 .SH SYNOPSIS

--- a/data/release/selinux/clad.te
+++ b/data/release/selinux/clad.te
@@ -1,4 +1,4 @@
-policy_module(clad, 0.5.1)
+policy_module(clad, 0.5.2)
 
 ########################################
 #

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,7 +12,7 @@ import sys
 project = "command-line assistant"
 copyright = "2025, RHEL Lightspeed Team"
 author = "RHEL Lightspeed Team"
-release = version = "0.5.1"
+release = version = "0.5.2"
 
 # Add the project root to Python path
 sys.path.insert(0, os.path.abspath("../.."))

--- a/packaging/command-line-assistant.spec
+++ b/packaging/command-line-assistant.spec
@@ -8,7 +8,7 @@
 %define modulename %{daemon_binary_name}
 
 Name:           command-line-assistant
-Version:        0.5.1
+Version:        0.5.2
 Release:        1%{?dist}
 Summary:        RHEL command-line assistant
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "command-line-assistant"
-version = "0.5.1"
+version = "0.5.2"
 description = " With the command-line assistant you can get guidance and assistance with managing RHEL right from your command line, all by using natural language. The generative AI that powers the command-line assistant incorporates information from the RHEL product documentation and Red Hat Knowledgebase, and can help you understand, configure, and troubleshoot your RHEL systems. "
 authors = [
     { name = "RHEL Lightspeed Team", email = "rhel-sst-lightspeed@redhat.com" },

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -21,7 +21,6 @@ VERSION_FILES = {
     "pyproject": PROJECT_ROOT / "pyproject.toml",
     "docs": PROJECT_ROOT / "docs" / "source" / "conf.py",
     "makefile": PROJECT_ROOT / "Makefile",
-    "containerfile": PROJECT_ROOT / "Containerfile",
 }
 
 
@@ -81,21 +80,6 @@ def update_pyproject_version(new_version: str) -> None:
     updated = re.sub(r'version = "[\d.]+"', f'version = "{new_version}"', content)
 
     with VERSION_FILES["pyproject"].open("w") as f:
-        f.write(updated)
-
-
-def update_containerfile_version(new_version: str) -> None:
-    """Update version in Containerfile.
-
-    Arguments:
-        new_version (str): New version to set
-    """
-    with VERSION_FILES["containerfile"].open("r") as f:
-        content = f.read()
-
-    updated = re.sub(r"VERSION=[\d.]+", f"VERSION={new_version}", content)
-
-    with VERSION_FILES["containerfile"].open("w") as f:
         f.write(updated)
 
 
@@ -335,9 +319,6 @@ def main() -> int:
 
         update_pyproject_version(args.version)
         print("✓ Updated pyproject.toml")
-
-        update_containerfile_version(args.version)
-        print("✓ Updated Containerfile")
 
         update_docs_version(args.version)
         print("✓ Updated conf.py")


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Bug Fixes 🐛
* [RSPEED-3420] Adjust the legal disclaimer when not using RH managed endpoint by @kokesak in https://github.com/rhel-lightspeed/command-line-assistant/pull/585
* [RSPEED-1947] Remove "rhel lightspeed" wording to align with the marketing strategy by @kokesak in https://github.com/rhel-lightspeed/command-line-assistant/pull/587
### Test Coverage Enhancements 🔧
* Update actions and add project token by @samdoran in https://github.com/rhel-lightspeed/command-line-assistant/pull/588
* [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci[bot] in https://github.com/rhel-lightspeed/command-line-assistant/pull/586

## New Contributors
* @Koncpa made their first contribution in https://github.com/rhel-lightspeed/command-line-assistant/pull/544
* @dependabot[bot] made their first contribution in https://github.com/rhel-lightspeed/command-line-assistant/pull/560

**Full Changelog**: https://github.com/rhel-lightspeed/command-line-assistant/compare/v0.5.1...v0.5.2

[RSPEED-3420]: https://redhat.atlassian.net/browse/RSPEED-3420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RSPEED-1947]: https://redhat.atlassian.net/browse/RSPEED-1947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ