### PR TITLE
[RSPEED-1912] Allow libffi closures in clad.service

### DIFF
--- a/data/release/systemd/clad.service
+++ b/data/release/systemd/clad.service
@@ -91,8 +91,10 @@ SystemCallFilter=@system-service
 SystemCallErrorNumber=EPERM
 
 # Additional security hardening
-# Prevents memory from being both writable and executable
-MemoryDenyWriteExecute=true
+# dasbus/PyGObject needs libffi closures. MemoryDenyWriteExecute
+# blocks ffi_closure_alloc() and logs "could not allocate closure"
+# on ppc64le (RHEL 10). See RSPEED-1912.
+MemoryDenyWriteExecute=false
 
 # Resource limitations
 # Sets maximum number of open files


### PR DESCRIPTION
Restarting `clad` on RHEL 10.0 ppc64le logs `could not allocate closure`.
That warning comes from gobject-introspection when `ffi_closure_alloc()`
fails. `MemoryDenyWriteExecute=true` in `clad.service` blocks the writable
executable mappings libffi needs for D-Bus callbacks.
This keeps the rest of the RSPEED-567 hardening and only turns MDWE off.
## Jira Issues
- https://issues.redhat.com/browse/RSPEED-1912
## Checklist
- [ ] Jira issue has been made public if possible
- [x] `[RSPEED-]` is part of the PR title
- [x] PR title explains the change from the user's point of view
- [x] Code and tests are documented properly
- [x] The commits are squashed to as few commits as possible (without losing data)
## Test plan
- [ ] On RHEL 10 ppc64le: `sudo systemctl restart clad` then `journalctl -u clad -p 4..7` has no `could not allocate closure`
- [ ] `c "hello"` still works after restart
- [ ] `systemd-analyze security clad` still reports the remaining hardening from RSPEED-567